### PR TITLE
[Bug] Fix/ refactor FunctionTy to use llvm::TrailingObjects for parameters

### DIFF
--- a/include/AST/Types/FunctionTy.hpp
+++ b/include/AST/Types/FunctionTy.hpp
@@ -37,6 +37,10 @@ private:
     FunctionTy(llvm::ArrayRef<TypeBase *> params, TypeBase *returnType)
         : FunctionTy(params.size(), returnType)
     {
+        std::uninitialized_copy(
+            params.begin(), params.end(),
+            this->template getTrailingObjects<TypeBase *>()
+        );
     }
 
 public:
@@ -53,13 +57,8 @@ public:
         void *mem = allocator.Allocate(
             totalSizeToAlloc<TypeBase *>(params.size()), alignof(FunctionTy)
         );
-        FunctionTy *funcTy = new (mem) FunctionTy(params, returnType);
 
-        std::uninitialized_copy(
-            params.begin(), params.end(),
-            funcTy->template getTrailingObjects<TypeBase *>()
-        );
-        return funcTy;
+        return new (mem) FunctionTy(params, returnType);
     }
 
     /// @brief Static function to check if a TypeBase is a FunctionTy.

--- a/include/AST/Types/FunctionTy.hpp
+++ b/include/AST/Types/FunctionTy.hpp
@@ -12,7 +12,6 @@ class FunctionTy final : public TypeBase,
 
 public:
     friend TrailingParams;
-    friend class InternedMemoryArena<TypeBase>;
 
 private:
     TypeBase * const _returnType;
@@ -27,15 +26,10 @@ private:
         return _numParams;
     }
 
-    FunctionTy(unsigned numParams, TypeBase *returnType)
-        : TypeBase(TypeKind::FunctionTyKind)
-        , _returnType(returnType)
-        , _numParams(numParams)
-    {
-    }
-
     FunctionTy(llvm::ArrayRef<TypeBase *> params, TypeBase *returnType)
-        : FunctionTy(params.size(), returnType)
+        : TypeBase(TypeKind::FunctionTyKind)
+        , _numParams(params.size())
+        , _returnType(returnType)
     {
         std::uninitialized_copy(
             params.begin(), params.end(),

--- a/include/AST/Types/FunctionTy.hpp
+++ b/include/AST/Types/FunctionTy.hpp
@@ -3,31 +3,69 @@
 
 #include "TypeBase.hpp"
 
-#include <vector>
-
 namespace glu::types {
 
 /// @brief FunctionTy is a class that represents a function type in the AST.
-class FunctionTy : public TypeBase {
-    std::vector<TypeBase *> const _parameters;
+class FunctionTy final : public TypeBase,
+                         private llvm::TrailingObjects<FunctionTy, TypeBase *> {
+    using TrailingParams = llvm::TrailingObjects<FunctionTy, TypeBase *>;
+
+public:
+    friend TrailingParams;
+    friend class InternedMemoryArena<TypeBase>;
+
+private:
     TypeBase * const _returnType;
+    unsigned _numParams;
+
+    // Method required by llvm::TrailingObjects to determine the number
+    // of trailing objects.
+    size_t
+        numTrailingObjects(typename TrailingParams::OverloadToken<TypeBase *>)
+            const
+    {
+        return _numParams;
+    }
+
+    FunctionTy(unsigned numParams, TypeBase *returnType)
+        : TypeBase(TypeKind::FunctionTyKind)
+        , _returnType(returnType)
+        , _numParams(numParams)
+    {
+    }
+
+    FunctionTy(llvm::ArrayRef<TypeBase *> params, TypeBase *returnType)
+        : FunctionTy(params.size(), returnType)
+    {
+    }
 
 public:
     /// @brief Constructor for the FunctionTy class.
-    /// @param parameters A vector of TypeBase pointers representing the
+    /// @param params A vector of TypeBase pointers representing the
     /// parameters of the function.
-    /// @param returnType A TypeBase pointer representing the return type of the
-    /// function.
-    FunctionTy(std::vector<TypeBase *> parameters, TypeBase *returnType)
-        : TypeBase(TypeKind::FunctionTyKind)
-        , _parameters(std::move(parameters))
-        , _returnType(returnType)
+    /// @param returnType A TypeBase pointer representing the return type of
+    /// the function.
+    static FunctionTy *create(
+        llvm::BumpPtrAllocator &allocator, llvm::ArrayRef<TypeBase *> params,
+        TypeBase *returnType
+    )
     {
+        void *mem = allocator.Allocate(
+            totalSizeToAlloc<TypeBase *>(params.size()), alignof(FunctionTy)
+        );
+        FunctionTy *funcTy = new (mem) FunctionTy(params, returnType);
+
+        std::uninitialized_copy(
+            params.begin(), params.end(),
+            funcTy->template getTrailingObjects<TypeBase *>()
+        );
+        return funcTy;
     }
 
     /// @brief Static function to check if a TypeBase is a FunctionTy.
     /// @param type The TypeBase to check.
-    /// @return Returns true if the TypeBase is a FunctionTy, false otherwise.
+    /// @return Returns true if the TypeBase is a FunctionTy, false
+    /// otherwise.
     static bool classof(TypeBase const *type)
     {
         return type->getKind() == TypeKind::FunctionTyKind;
@@ -38,13 +76,22 @@ public:
     /// @return Returns a TypeBase pointer representing the parameter
     TypeBase *getParameter(std::size_t index) const
     {
-        assert(index < _parameters.size() && "Index out of bounds");
-        return _parameters[index];
+        assert(index < _numParams && "Index out of bounds");
+
+        return getTrailingObjects<TypeBase *>()[index];
+    }
+
+    /// @brief Getter for all parameters of the function.
+    /// @return Returns an ArrayRef of TypeBase pointers representing the
+    /// function's parameters.
+    llvm::ArrayRef<TypeBase *> getParameters() const
+    {
+        return { getTrailingObjects<TypeBase *>(), _numParams };
     }
 
     /// @brief Getter for the number of parameters of the function.
     /// @return Returns the number of parameters
-    std::size_t getParameterCount() const { return _parameters.size(); }
+    std::size_t getParameterCount() const { return _numParams; }
 
     /// @brief Getter for the return type of the function.
     /// @return Returns a TypeBase pointer representing the return type

--- a/include/Basic/InternedMemoryArena.hpp
+++ b/include/Basic/InternedMemoryArena.hpp
@@ -52,10 +52,9 @@ class InternedMemoryArena : public TypedMemoryArena<Base> {
 
         llvm::BumpPtrAllocator tmpAllocator;
 
-        T *tmp
-            = static_cast<TypedMemoryArena<Base> *>(this)->template create<T>(
-                tmpAllocator, std::forward<Args>(args)...
-            );
+        T *tmp = this->template createWithAllocator<T>(
+            tmpAllocator, std::forward<Args>(args)...
+        );
 
         auto it = _internedSet.find_as(tmp);
         if (it != _internedSet.end())

--- a/include/Basic/InternedMemoryArena.hpp
+++ b/include/Basic/InternedMemoryArena.hpp
@@ -8,7 +8,6 @@
 #include <llvm/Support/Casting.h>
 
 #include <type_traits>
-#include <utility>
 
 namespace glu {
 
@@ -50,8 +49,15 @@ class InternedMemoryArena : public TypedMemoryArena<Base> {
 
     template <typename T, typename... Args> T *findInterned(Args &&...args)
     {
-        T tmp(std::forward<Args>(args)...);
-        auto it = _internedSet.find_as(&tmp);
+
+        llvm::BumpPtrAllocator tmpAllocator;
+
+        T *tmp
+            = static_cast<TypedMemoryArena<Base> *>(this)->template create<T>(
+                tmpAllocator, std::forward<Args>(args)...
+            );
+
+        auto it = _internedSet.find_as(tmp);
         if (it != _internedSet.end())
             return llvm::cast<T>(*it);
         return nullptr;

--- a/include/Basic/TypedMemoryArena.hpp
+++ b/include/Basic/TypedMemoryArena.hpp
@@ -43,6 +43,18 @@ public:
         return T::create(this->getAllocator(), std::forward<Args>(args)...);
     }
 
+    template <typename T, typename... Args>
+    CreateReturnStatic<T, Args...>
+    create(llvm::BumpPtrAllocator &allocator, Args &&...args)
+    {
+        static_assert(
+            std::is_base_of_v<Base, T>,
+            "T must be a subclass of the base class used by the memory arena"
+        );
+
+        return T::create(allocator, std::forward<Args>(args)...);
+    }
+
     /// @brief Creates and allocates an object of type T within the memory
     /// arena.
     ///
@@ -63,6 +75,18 @@ public:
             "T must be a subclass of the base class used by the memory arena"
         );
         return allocate<T>(std::forward<Args>(args)...);
+    }
+
+    template <typename T, typename... Args>
+    CreateReturnNonStatic<T, Args...>
+    create(llvm::BumpPtrAllocator &allocator, Args &&...args)
+    {
+        static_assert(
+            std::is_base_of_v<Base, T>,
+            "T must be a subclass of the base class used by the memory arena"
+        );
+        void *mem = allocator.Allocate(sizeof(T), alignof(T));
+        return new (mem) T(std::forward<Args>(args)...);
     }
 };
 

--- a/lib/AST/HashType.cpp
+++ b/lib/AST/HashType.cpp
@@ -33,11 +33,6 @@ public:
         std::size_t hash
             = llvm::hash_combine(type->getKind(), type->getReturnType());
 
-        auto parameters = type->getParameterCount();
-        for (std::size_t i = 0; i < parameters; ++i) {
-            hash = llvm::hash_combine(hash, type->getParameter(i));
-        }
-
         return hash;
     };
 
@@ -126,11 +121,6 @@ public:
                 || type->getParameterCount()
                     != otherFunction->getParameterCount()) {
                 return false;
-            }
-
-            for (std::size_t i = 0, n = type->getParameterCount(); i < n; ++i) {
-                if (type->getParameter(i) != otherFunction->getParameter(i))
-                    return false;
             }
 
             return true;

--- a/lib/AST/HashType.cpp
+++ b/lib/AST/HashType.cpp
@@ -33,6 +33,11 @@ public:
         std::size_t hash
             = llvm::hash_combine(type->getKind(), type->getReturnType());
 
+        auto parameters = type->getParameterCount();
+        for (std::size_t i = 0; i < parameters; ++i) {
+            hash = llvm::hash_combine(hash, type->getParameter(i));
+        }
+
         return hash;
     };
 
@@ -121,6 +126,11 @@ public:
                 || type->getParameterCount()
                     != otherFunction->getParameterCount()) {
                 return false;
+            }
+
+            for (std::size_t i = 0, n = type->getParameterCount(); i < n; ++i) {
+                if (type->getParameter(i) != otherFunction->getParameter(i))
+                    return false;
             }
 
             return true;


### PR DESCRIPTION
This pull request introduces significant changes to the `FunctionTy` class in the Abstract Syntax Tree (AST) to enhance its memory management and efficiency. The main changes include the adoption of LLVM's `TrailingObjects` for parameter storage, the addition of new constructors, and the removal of redundant methods in related classes.

Improvements to `FunctionTy` class:

* [`include/AST/Types/FunctionTy.hpp`](diffhunk://#diff-2962c098743fb9fdcc1deb6a58c8a5911dc0e935275101c366e4d6cb491312a7L6-R68): Modified `FunctionTy` to use LLVM's `TrailingObjects` for storing parameters, added new constructors, and updated the `create` method to allocate memory for trailing objects.
* [`include/AST/Types/FunctionTy.hpp`](diffhunk://#diff-2962c098743fb9fdcc1deb6a58c8a5911dc0e935275101c366e4d6cb491312a7L41-R94): Updated getter methods to retrieve parameters using `TrailingObjects` and replaced `_parameters` with `_numParams` for parameter count.

# Important Notes

Due to the need of dynamic allocation in our arena, the `parameters` stored in the `FunctionTy`'s TrailingObjects class cannot be accessed in our `HashType` class. This lead to a serious lack of consistency in our equality checks as well as an incomplete hashed data.

> !Important -> This need to be refactored or discussed ASAP.