### PR TITLE
Refactor: replace `std::string` by `llvm::StringRef` and use `llvm::TrailingObjects`

### DIFF
--- a/include/AST/Decl/TypeAliasDecl.hpp
+++ b/include/AST/Decl/TypeAliasDecl.hpp
@@ -28,7 +28,7 @@ public:
     /// the type alias.
     TypeAliasDecl(
         ASTContext &context, SourceLocation location, ASTNode *parent,
-        std::string name, glu::types::TypeBase *wrapped
+        llvm::StringRef name, glu::types::TypeBase *wrapped
     )
         : DeclBase(NodeKind::TypeAliasDeclKind, location, parent)
         , _self(context.getTypesMemoryArena().create<TypeAliasTy>(
@@ -39,7 +39,7 @@ public:
 
     /// @brief Getter for the name of the type alias.
     /// @return Returns the name of the type alias.
-    std::string getName() const { return _self->getName(); }
+    llvm::StringRef getName() const { return _self->getName(); }
 
     /// @brief Getter for the type of this type alias.
     /// @return Returns the type of this type alias.

--- a/include/AST/Stmt/CompoundStmt.hpp
+++ b/include/AST/Stmt/CompoundStmt.hpp
@@ -60,7 +60,8 @@ public:
     {
         auto totalSize = totalSizeToAlloc<StmtBase *>(stmts.size());
         void *mem = alloc.Allocate(totalSize, alignof(CompoundStmt));
-        return new (mem) CompoundStmt(location, std::move(stmts));
+
+        return new (mem) CompoundStmt(location, stmts);
     }
 
     /// @brief Get the list of statements in the compound statement.

--- a/include/AST/Stmt/CompoundStmt.hpp
+++ b/include/AST/Stmt/CompoundStmt.hpp
@@ -4,7 +4,6 @@
 #include "ASTNode.hpp"
 
 #include <llvm/ADT/ArrayRef.h>
-#include <llvm/ADT/SmallVector.h>
 #include <llvm/Support/Allocator.h>
 #include <llvm/Support/TrailingObjects.h>
 
@@ -35,11 +34,11 @@ class CompoundStmt final
     /// @param location The source location of the compound statement.
     /// @param stmts A vector of StmtBase pointers representing the statements
     /// in the compound statement.
-    CompoundStmt(SourceLocation location, llvm::SmallVector<StmtBase *> stmts)
+    CompoundStmt(SourceLocation location, llvm::ArrayRef<StmtBase *> stmts)
         : StmtBase(NodeKind::CompoundStmtKind, location)
         , _stmtCount(stmts.size())
     {
-        for (auto &stmt : stmts)
+        for (auto *stmt : stmts)
             stmt->setParent(this);
         std::uninitialized_copy(
             stmts.begin(), stmts.end(),
@@ -56,7 +55,7 @@ public:
     /// @return A pointer to the newly created CompoundStmt.
     static CompoundStmt *create(
         llvm::BumpPtrAllocator &alloc, SourceLocation location,
-        llvm::SmallVector<StmtBase *> stmts
+        llvm::ArrayRef<StmtBase *> stmts
     )
     {
         auto totalSize = totalSizeToAlloc<StmtBase *>(stmts.size());

--- a/include/AST/Stmt/CompoundStmt.hpp
+++ b/include/AST/Stmt/CompoundStmt.hpp
@@ -5,6 +5,8 @@
 
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/SmallVector.h>
+#include <llvm/Support/Allocator.h>
+#include <llvm/Support/TrailingObjects.h>
 
 namespace glu::ast {
 
@@ -13,20 +15,60 @@ namespace glu::ast {
 ///
 /// This class inherits from StmtBase and encapsulates the details of a compound
 /// statement, including its list of statements.
-class CompoundStmt : public StmtBase {
-    llvm::SmallVector<StmtBase *> _stmts;
+class CompoundStmt final
+    : public StmtBase,
+      private llvm::TrailingObjects<CompoundStmt, StmtBase *> {
+    using TrailingArgs = llvm::TrailingObjects<CompoundStmt, StmtBase *>;
+    friend TrailingArgs;
 
-public:
+    unsigned _stmtCount;
+
+    // Method required by llvm::TrailingObjects to determine the number
+    // of trailing objects.
+    size_t
+        numTrailingObjects(typename TrailingArgs::OverloadToken<StmtBase *>) const
+    {
+        return _stmtCount;
+    }
+
     /// @brief Constructor for the CompoundStmt class.
     /// @param location The source location of the compound statement.
     /// @param stmts A vector of StmtBase pointers representing the statements
     /// in the compound statement.
     CompoundStmt(SourceLocation location, llvm::SmallVector<StmtBase *> stmts)
         : StmtBase(NodeKind::CompoundStmtKind, location)
-        , _stmts(std::move(stmts))
+        , _stmtCount(stmts.size())
     {
-        for (auto stmt : _stmts)
+        for (auto &stmt : stmts)
             stmt->setParent(this);
+        std::uninitialized_copy(
+            stmts.begin(), stmts.end(),
+            this->template getTrailingObjects<StmtBase *>()
+        );
+    }
+
+public:
+    /// @brief Static method to create a new CompoundStmt.
+    /// @param alloc The allocator used to create the CompoundStmt.
+    /// @param location The source location of the compound statement.
+    /// @param stmts A vector of StmtBase pointers representing the statements
+    /// in the compound statement.
+    /// @return A pointer to the newly created CompoundStmt.
+    static CompoundStmt *create(
+        llvm::BumpPtrAllocator &alloc, SourceLocation location,
+        llvm::SmallVector<StmtBase *> stmts
+    )
+    {
+        auto totalSize = totalSizeToAlloc<StmtBase *>(stmts.size());
+        void *mem = alloc.Allocate(totalSize, alignof(CompoundStmt));
+        return new (mem) CompoundStmt(location, std::move(stmts));
+    }
+
+    /// @brief Get the list of statements in the compound statement.
+    /// @return A reference to the list of statements.
+    llvm::ArrayRef<StmtBase *> getStmts()
+    {
+        return { getTrailingObjects<StmtBase *>(), _stmtCount };
     }
 
     /// @brief Check if the given node is a compound statement.
@@ -35,28 +77,6 @@ public:
     static bool classof(ASTNode const *node)
     {
         return node->getKind() == NodeKind::CompoundStmtKind;
-    }
-
-    /// @brief Get the list of statements in the compound statement.
-    /// @return A reference to the list of statements.
-    llvm::ArrayRef<StmtBase *> getStmts() { return _stmts; }
-
-    /// @brief Add a statement to the compound statement.
-    /// @param stmt The statement to add.
-    void addStmt(StmtBase *stmt)
-    {
-        stmt->setParent(this);
-        _stmts.push_back(stmt);
-    }
-
-    /// @brief Remove a statement from the compound statement.
-    /// @param stmt The statement to remove.
-    void removeStmt(StmtBase *stmt)
-    {
-        stmt->setParent(nullptr);
-        _stmts.erase(
-            std::remove(_stmts.begin(), _stmts.end(), stmt), _stmts.end()
-        );
     }
 };
 

--- a/include/AST/Types/TypeAliasTy.hpp
+++ b/include/AST/Types/TypeAliasTy.hpp
@@ -9,7 +9,7 @@ namespace glu::types {
 /// @brief TypeAliasTy is a class that represents the TypeAlias type in the AST.
 class TypeAliasTy : public TypeBase {
     TypeBase * const _wrappedType;
-    std::string _name;
+    llvm::StringRef _name;
     glu::SourceLocation _location;
 
 public:
@@ -18,11 +18,12 @@ public:
     /// @param name The name of the alias.
     /// @param location The source location where the alias is defined.
     TypeAliasTy(
-        TypeBase *wrappedType, std::string name, glu::SourceLocation location
+        TypeBase *wrappedType, llvm::StringRef name,
+        glu::SourceLocation location
     )
         : TypeBase(TypeKind::TypeAliasTyKind)
         , _wrappedType(wrappedType)
-        , _name(std::move(name))
+        , _name(name)
         , _location(location)
     {
     }
@@ -33,7 +34,7 @@ public:
 
     /// @brief Getter for the alias name.
     /// @return The name of the alias.
-    std::string const &getName() const { return _name; }
+    llvm::StringRef getName() const { return _name; }
 
     /// @brief Getter for the source location.
     /// @return The source location of the alias.

--- a/include/AST/Types/UnresolvedNameTy.hpp
+++ b/include/AST/Types/UnresolvedNameTy.hpp
@@ -9,17 +9,17 @@ namespace glu::types {
 /// @brief UnresolvedNameTy is a class that represents an unresolved name type
 /// in the AST.
 class UnresolvedNameTy : public TypeBase {
-    std::string const _name;
+    llvm::StringRef _name;
 
 public:
-    UnresolvedNameTy(std::string name)
-        : TypeBase(TypeKind::UnresolvedNameTyKind), _name(std::move(name))
+    UnresolvedNameTy(llvm::StringRef name)
+        : TypeBase(TypeKind::UnresolvedNameTyKind), _name(name)
     {
     }
 
     /// @brief Getter for the name of the unresolved type.
     /// @return The name of the unresolved type.
-    std::string const &getName() const { return _name; }
+    llvm::StringRef getName() const { return _name; }
 
     static bool classof(TypeBase const *type)
     {

--- a/test/AST/Decl/FunctionDecl.cpp
+++ b/test/AST/Decl/FunctionDecl.cpp
@@ -42,8 +42,11 @@ TEST_F(FunctionDeclTest, FunctionDeclConstructor)
         ParamDecl(loc, "b", boolType, arg2),
     };
 
+    auto body = ctx.getASTMemoryArena().create<CompoundStmt>(
+        loc, std::vector<StmtBase *> {}
+    );
     auto const func = ctx.getASTMemoryArena().create<FunctionDecl>(
-        loc, nullptr, name, funcTy, std::move(params)
+        loc, nullptr, name, funcTy, std::move(params), body
     );
 
     ASSERT_EQ(func->getName(), name);

--- a/test/AST/Stmt/CompoundStmt.cpp
+++ b/test/AST/Stmt/CompoundStmt.cpp
@@ -8,38 +8,13 @@ using namespace glu::ast;
 
 TEST(CompoundStmt, CompoundStmtConstructor)
 {
+    llvm::BumpPtrAllocator alloc;
     llvm::SmallVector<StmtBase *> stmts;
     auto loc = glu::SourceLocation(42);
 
-    CompoundStmt stmt(loc, std::move(stmts));
+    auto stmt = CompoundStmt::create(alloc, loc, std::move(stmts));
 
-    ASSERT_TRUE(llvm::isa<CompoundStmt>(&stmt));
-    ASSERT_TRUE(stmt.getStmts().empty());
-}
-
-TEST(CompoundStmt, CompoundStmtAddAndRemoveStmts)
-{
-    llvm::SmallVector<StmtBase *> stmts;
-    auto loc = glu::SourceLocation(42);
-
-    CompoundStmt stmt(loc, std::move(stmts));
-
-    auto stmt1 = new CompoundStmt(loc, {});
-    auto stmt2 = new CompoundStmt(loc, {});
-
-    stmt.addStmt(stmt1);
-    stmt.addStmt(stmt2);
-
-    ASSERT_EQ(stmt.getStmts().size(), 2);
-    ASSERT_EQ(stmt.getStmts()[0], stmt1);
-    ASSERT_EQ(stmt.getStmts()[1], stmt2);
-    ASSERT_EQ(stmt1->getParent(), &stmt);
-
-    stmt.removeStmt(stmt1);
-
-    ASSERT_EQ(stmt.getStmts().size(), 1);
-    ASSERT_EQ(stmt.getStmts()[0], stmt2);
-
-    delete stmt1;
-    delete stmt2;
+    ASSERT_TRUE(llvm::isa<CompoundStmt>(stmt));
+    ASSERT_TRUE(stmt->getStmts().empty());
+    ASSERT_EQ(stmt->getLocation(), loc);
 }

--- a/test/AST/Stmt/WhileStmt.cpp
+++ b/test/AST/Stmt/WhileStmt.cpp
@@ -15,13 +15,14 @@ public:
 
 TEST(WhileStmt, WhileStmtConstructor)
 {
+    llvm::BumpPtrAllocator alloc;
     auto loc = glu::SourceLocation(42);
     auto condition = TestExprBase();
-    CompoundStmt body(loc, {});
+    auto body = CompoundStmt::create(alloc, loc, {});
 
-    WhileStmt stmt(loc, &condition, &body);
+    WhileStmt stmt(loc, &condition, body);
 
     ASSERT_TRUE(llvm::isa<WhileStmt>(&stmt));
     ASSERT_EQ(stmt.getCondition(), &condition);
-    ASSERT_EQ(stmt.getBody(), &body);
+    ASSERT_EQ(stmt.getBody(), body);
 }


### PR DESCRIPTION
fix #265