### PR TITLE
[DevOps] CI: Linux Smoke Tests

### DIFF
--- a/.github/workflows/linux_smoke-tests.yml
+++ b/.github/workflows/linux_smoke-tests.yml
@@ -3,6 +3,7 @@ name: 🐧 Linux Smoke Tests
 on:
   workflow_call:
   workflow_dispatch:
+  push:
 
 jobs:
   build_ubuntu:

--- a/.github/workflows/linux_smoke-tests.yml
+++ b/.github/workflows/linux_smoke-tests.yml
@@ -38,8 +38,5 @@ jobs:
       - name: "Configure the project"
         run: "cmake -Bbuild -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLLVM_ENABLE_ASSERTIONS=1"
 
-      - name: "Compile the code"
-        run: "cmake --build build -j$(nproc)"
-
       - name: "Run unit tests"
-        run: "cd build/tests; ./unit_tests"
+        run: "./coverage.sh"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,12 +12,17 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 project(Glu CXX C)
 
-# include(FetchLLVM)
-find_package(LLVM 18.1.8 REQUIRED CONFIG)
-message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
-message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
-include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
-add_definitions(${LLVM_DEFINITIONS})
+option(FROM_SOURCE "Use LLVM built from source" OFF)
+
+if(FROM_SOURCE)
+    include(FetchLLVM)
+else()
+    find_package(LLVM 18.1.8 REQUIRED CONFIG)
+    message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+    message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+    include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
+    add_definitions(${LLVM_DEFINITIONS})
+endif()
 
 include(UnixCompileRules)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,16 @@ set(CMAKE_CXX_COMPILER clang++)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-project(Glu CXX)
+project(Glu CXX C)
+
+# include(FetchLLVM)
+find_package(LLVM 18.1.8 REQUIRED CONFIG)
+message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
+add_definitions(${LLVM_DEFINITIONS})
 
 include(UnixCompileRules)
-include(FetchLLVM)
 
 find_package(FLEX)
 


### PR DESCRIPTION

This pull request includes several changes to the build and test configuration for the project. The most important changes focus on enhancing the Linux smoke tests and improving the CMake configuration.

### Enhancements to Linux smoke tests:

* [`.github/workflows/linux_smoke-tests.yml`](diffhunk://#diff-9969b6cf9509891ccdb4fe16f941dad74b05f3cadd707f1f309a8aad2478185aR6): Added a `push` trigger to the workflow to ensure tests run on every push.
* [`.github/workflows/linux_smoke-tests.yml`](diffhunk://#diff-9969b6cf9509891ccdb4fe16f941dad74b05f3cadd707f1f309a8aad2478185aL40-R42): Updated the unit test step to run `./coverage.sh` instead of directly running the unit tests.

### Improvements to CMake configuration:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL13-R27): Added an option to use LLVM built from source or find an existing LLVM package, enhancing flexibility in the build process.

fix: #304