### PR TITLE
Feature: Add DeclStmt in AST and Parser

### DIFF
--- a/include/AST/NodeKind.def
+++ b/include/AST/NodeKind.def
@@ -28,6 +28,7 @@
 #endif
 
 NODE_KIND_SUPER(StmtBase, ASTNode)
+    NODE_KIND_(DeclStmt, StmtBase, NODE_CHILD(DeclBase, Decl))
     NODE_KIND_(ReturnStmt, StmtBase, NODE_CHILD(ExprBase, ReturnExpr))
     NODE_KIND_(IfStmt, StmtBase, NODE_CHILD(ExprBase, Condition), NODE_CHILD(CompoundStmt, Body), NODE_CHILD(CompoundStmt, Else))
     NODE_KIND_(WhileStmt, StmtBase, NODE_CHILD(ExprBase, Condition), NODE_CHILD(CompoundStmt, Body))

--- a/include/AST/Stmt/DeclStmt.hpp
+++ b/include/AST/Stmt/DeclStmt.hpp
@@ -1,0 +1,37 @@
+#ifndef GLU_AST_STMT_DECLSTMT_HPP
+#define GLU_AST_STMT_DECLSTMT_HPP
+
+#include "ASTNode.hpp"
+
+namespace glu::ast {
+
+/// @class DeclStmt
+/// @brief Represents a decl statement in the AST.
+///
+/// This class inherits from StmtBase and encapsulates the details of a decl
+/// statement.
+class DeclStmt : public StmtBase {
+    /// @brief The declaration associated with this statement.
+    DeclBase *_decl;
+
+public:
+    DeclStmt(SourceLocation location, DeclBase *decl)
+        : StmtBase(NodeKind::DeclStmtKind, location), _decl(decl)
+    {
+        assert(_decl && "Declaration cannot be null.");
+        _decl->setParent(this);
+    }
+
+    /// @brief Returns the declaration associated with this statement.
+    DeclBase *getDecl() const { return _decl; }
+
+    /// @brief Check if the given node is a decl statement.
+    static bool classof(ASTNode const *node)
+    {
+        return node->getKind() == NodeKind::DeclStmtKind;
+    }
+};
+
+}
+
+#endif // GLU_AST_STMT_DECLSTMT_HPP

--- a/include/AST/Stmts.hpp
+++ b/include/AST/Stmts.hpp
@@ -5,9 +5,10 @@
 #include "Stmt/BreakStmt.hpp"
 #include "Stmt/CompoundStmt.hpp"
 #include "Stmt/ContinueStmt.hpp"
+#include "Stmt/DeclStmt.hpp"
 #include "Stmt/ExpressionStmt.hpp"
-#include "Stmt/IfStmt.hpp"
 #include "Stmt/ForStmt.hpp"
+#include "Stmt/IfStmt.hpp"
 #include "Stmt/ReturnStmt.hpp"
 #include "Stmt/WhileStmt.hpp"
 

--- a/lib/Parser/Parser.yy
+++ b/lib/Parser/Parser.yy
@@ -83,9 +83,9 @@
 
 %type <TypeBase *> type type_opt array_type primary_type pointer_type function_type_param_types function_type_param_types_tail function_return_type
 
-%type <DeclBase *> var_stmt let_stmt type_declaration struct_declaration enum_declaration typealias_declaration function_declaration
+%type <DeclBase *> type_declaration struct_declaration enum_declaration typealias_declaration function_declaration
 
-%type <StmtBase *> statement expression_stmt assignment_or_call_stmt return_stmt if_stmt while_stmt for_stmt break_stmt continue_stmt
+%type <StmtBase *> statement expression_stmt assignment_or_call_stmt var_stmt let_stmt return_stmt if_stmt while_stmt for_stmt break_stmt continue_stmt
 
 %type <CompoundStmt *> else_opt
 %type <CompoundStmt *> block function_body
@@ -643,7 +643,8 @@ function_template_arguments:
 var_stmt:
       varKw ident type_opt initializer_opt semi
       {
-        $$ = CREATE_NODE<VarDecl>(LOC($2), $2.getLexeme().str(), $3, $4);
+        auto varDecl = CREATE_NODE<VarDecl>(LOC($2), $2.getLexeme(), $3, $4);
+        $$ = CREATE_NODE<DeclStmt>(LOC($2), varDecl);
         std::cerr << "Parsed var declaration: " << $2.getLexeme().str() << std::endl;
       }
     ;
@@ -671,7 +672,8 @@ initializer_opt:
 let_stmt:
       letKw ident type_opt equal expression semi
       {
-        $$ = CREATE_NODE<LetDecl>(LOC($2), $2.getLexeme().str(), $3, $5);
+        auto letDecl = CREATE_NODE<LetDecl>(LOC($2), $2.getLexeme(), $3, $5);
+        $$ = CREATE_NODE<DeclStmt>(LOC($2), letDecl);
         std::cerr << "Parsed let declaration: " << $2.getLexeme().str() << std::endl;
       }
     ;

--- a/lib/Parser/Parser.yy
+++ b/lib/Parser/Parser.yy
@@ -466,7 +466,7 @@ enum_variant:
 typealias_declaration:
       attributes typealiasKw ident template_definition_opt equal type semi
       {
-        $$ = CREATE_NODE<TypeAliasDecl>(ctx, LOC($3), nullptr, $3.getLexeme().str(), $6);
+        $$ = CREATE_NODE<TypeAliasDecl>(ctx, LOC($3), nullptr, $3.getLexeme(), $6);
         std::cerr << "Parsed typealias declaration" << std::endl;
       }
     ;
@@ -722,7 +722,7 @@ for_stmt:
       {
         auto binding = CREATE_NODE<ForBindingDecl>(
           LOC($2),
-          $2.getLexeme().str(),
+          $2.getLexeme(),
           CREATE_TYPE<TypeVariableTy>());
 
         $$ = CREATE_NODE<ForStmt>(LOC($1), binding, $4, $5);
@@ -972,9 +972,7 @@ primary_type:
     | lParen function_type_param_types rParen arrow primary_type { $$ = $5; }
     | namespaced_identifier template_arguments_opt
       {
-        std::string name = static_cast<RefExpr *>($1)->getIdentifier().str();
-        $$ = CREATE_TYPE<UnresolvedNameTy>(name);
-        std::cerr << "Parsed type: " << name << std::endl;
+        $$ = CREATE_TYPE<UnresolvedNameTy>(static_cast<RefExpr *>($1)->getIdentifier());
       }
     | pointer_type
     ;

--- a/test/AST/ASTWalker.cpp
+++ b/test/AST/ASTWalker.cpp
@@ -71,13 +71,13 @@ TEST(ASTWalker, Example)
     visitor.visit(node);
     EXPECT_EQ(
         visitor.acc.str(),
-        "Visiting Node with Kind 2\n"
+        "Visiting Node with Kind 3\n"
         "  Visiting a Lit! \n"
-        "  Visiting Node with Kind 9\n"
-        "    Visiting Node with Kind 7\n"
-        "      Visiting Node with Kind 16\n"
+        "  Visiting Node with Kind 10\n"
+        "    Visiting Node with Kind 8\n"
+        "      Visiting Node with Kind 17\n"
         "      Visiting a Lit! \n"
-        "    Visiting Node with Kind 5\n"
-        "  Visiting Node with Kind 9\n"
+        "    Visiting Node with Kind 6\n"
+        "  Visiting Node with Kind 10\n"
     );
 }


### PR DESCRIPTION
This pull request introduces a new `DeclStmt` class to the Abstract Syntax Tree (AST) and updates the parser to utilize this new statement type. The main changes include defining the `DeclStmt` class, updating the node kind definitions, modifying the parser to create `DeclStmt` nodes, and adjusting the test cases accordingly.

### Introduction of `DeclStmt`:

* [`include/AST/NodeKind.def`](diffhunk://#diff-7dd7aa8b128141693710e0be8a3721bf3e471efb0276dfbd20a6d0ae82e6680eR31): Added `DeclStmt` to the node kind definitions.
* [`include/AST/Stmt/DeclStmt.hpp`](diffhunk://#diff-d963e1364977883922f6bf2f4be98c6104375d2794c38ff560ad2c841e972745R1-R37): Defined the `DeclStmt` class, which represents a declaration statement in the AST.
* [`include/AST/Stmts.hpp`](diffhunk://#diff-40a8f033156d0e0eceaecfdee077e5f0025cb1a499811e2beec7b34366487d75R8-R11): Included the new `DeclStmt.hpp` header file.

### Parser updates:

* [`lib/Parser/Parser.yy`](diffhunk://#diff-e54bd1140731f8b103011c48aa72e69b83623aa5fae5f46e04291f4ca3df99c8L86-R88): Updated the parser rules to create `DeclStmt` nodes for `var_stmt` and `let_stmt`. This includes modifying the `statement` type to recognize `var_stmt` and `let_stmt` as `StmtBase` types. [[1]](diffhunk://#diff-e54bd1140731f8b103011c48aa72e69b83623aa5fae5f46e04291f4ca3df99c8L86-R88) [[2]](diffhunk://#diff-e54bd1140731f8b103011c48aa72e69b83623aa5fae5f46e04291f4ca3df99c8L646-R647) [[3]](diffhunk://#diff-e54bd1140731f8b103011c48aa72e69b83623aa5fae5f46e04291f4ca3df99c8L674-R676)

### Test case adjustments:

* [`test/AST/ASTWalker.cpp`](diffhunk://#diff-2ac60083d677c83163c1174d7cf8d1ede2b23756b2af9db1831d7308ad28ed48L74-R81): Updated expected node kinds in the AST walker test to reflect the new node kind values.

fix: #297 