### PR TITLE
chore: delete useless warnings

### DIFF
--- a/lib/AST/HashType.cpp
+++ b/lib/AST/HashType.cpp
@@ -191,7 +191,7 @@ public:
         return false;
     }
 
-    bool visitTypeVariableTy([[maybe_unused]] TypeVariableTy *type, TypeBase *other)
+    bool visitTypeVariableTy([[maybe_unused]] TypeVariableTy *type, [[maybe_unused]] TypeBase *other)
     {
         return false;
     }

--- a/lib/GILGen/GILGenStmt.cpp
+++ b/lib/GILGen/GILGenStmt.cpp
@@ -37,7 +37,7 @@ struct GILGenStmt : public ASTVisitor<GILGenStmt, void> {
     void pushScope(Scope &&scope) { scopes.push_back(std::move(scope)); }
     void popScope() { scopes.pop_back(); }
 
-    void visitStmtBase(StmtBase *stmt)
+    void visitStmtBase([[maybe_unused]] StmtBase *stmt)
     {
         assert(false && "Unknown statement kind");
     }
@@ -55,7 +55,7 @@ struct GILGenStmt : public ASTVisitor<GILGenStmt, void> {
             visit(child);
     }
 
-    void visitBreakStmt(BreakStmt *stmt)
+    void visitBreakStmt([[maybe_unused]] BreakStmt *stmt)
     {
         Scope *scope = &getCurrentScope();
         while (scope && !scope->isLoopScope())
@@ -65,7 +65,7 @@ struct GILGenStmt : public ASTVisitor<GILGenStmt, void> {
         ctx.positionAtEnd(ctx.buildUnreachableBB());
     }
 
-    void visitContinueStmt(ContinueStmt *stmt)
+    void visitContinueStmt([[maybe_unused]] ContinueStmt *stmt)
     {
         Scope *scope = &getCurrentScope();
         while (scope && !scope->isLoopScope())

--- a/test/AST/ASTWalker.cpp
+++ b/test/AST/ASTWalker.cpp
@@ -14,8 +14,8 @@ struct TestVisitor : public ASTWalker<TestVisitor, TraversalOrder::PreOrder> {
     int indent = -1;
     std::ostringstream acc;
 
-    void beforeVisitNode(ASTNode *node) { indent++; }
-    void afterVisitNode(ASTNode *node) { indent--; }
+    void beforeVisitNode([[maybe_unused]] ASTNode *node) { indent++; }
+    void afterVisitNode([[maybe_unused]] ASTNode *node) { indent--; }
     void visitASTNode(ASTNode *node)
     {
         for (int i = 0; i < indent; ++i) {
@@ -23,7 +23,7 @@ struct TestVisitor : public ASTWalker<TestVisitor, TraversalOrder::PreOrder> {
         }
         acc << "Visiting Node with Kind " << size_t(node->getKind()) << '\n';
     }
-    void visitLiteralExpr(ASTNode *node)
+    void visitLiteralExpr([[maybe_unused]] ASTNode *node)
     {
         for (int i = 0; i < indent; ++i) {
             acc << "  ";

--- a/test/AST/Types/TypeVisitor.cpp
+++ b/test/AST/Types/TypeVisitor.cpp
@@ -4,22 +4,22 @@
 // Example class to test the visitor pattern for types
 class TestVisitor : public glu::types::TypeVisitor<TestVisitor, std::string> {
 public:
-    std::string visitIntTy(glu::types::TypeBase *type)
+    std::string visitIntTy([[maybe_unused]] glu::types::TypeBase *type)
     {
         return "Visiting IntType";
     }
 
-    std::string visitBoolTy(glu::types::TypeBase *type)
+    std::string visitBoolTy([[maybe_unused]] glu::types::TypeBase *type)
     {
         return "Visiting BoolType";
     }
 
-    std::string visitCharTy(glu::types::TypeBase *type)
+    std::string visitCharTy([[maybe_unused]] glu::types::TypeBase *type)
     {
         return "Visiting CharType";
     }
 
-    std::string visitTypeBase(glu::types::TypeBase *type)
+    std::string visitTypeBase([[maybe_unused]] glu::types::TypeBase *type)
     {
         return "Visiting default TypeBase";
     }


### PR DESCRIPTION
This pull request includes multiple changes across various files to add the `[[maybe_unused]]` attribute to function parameters that are not used within their respective functions. This helps to suppress compiler warnings about unused parameters.

Changes to add `[[maybe_unused]]` attribute:

* [`lib/AST/HashType.cpp`](diffhunk://#diff-72656c20e6a4b353cb4929aef44184e5fb3eb22f632dce6ed04eac7f555f912cL194-R194): Added `[[maybe_unused]]` attribute to the `other` parameter in the `visitTypeVariableTy` method.
* [`lib/GILGen/GILGenStmt.cpp`](diffhunk://#diff-c9b929f74c933a55dee01f07769aa256d1dfa1e6c49b81eed601b997716b7ea4L40-R40): Added `[[maybe_unused]]` attribute to the `stmt` parameter in the `visitStmtBase`, `visitBreakStmt`, and `visitContinueStmt` methods. [[1]](diffhunk://#diff-c9b929f74c933a55dee01f07769aa256d1dfa1e6c49b81eed601b997716b7ea4L40-R40) [[2]](diffhunk://#diff-c9b929f74c933a55dee01f07769aa256d1dfa1e6c49b81eed601b997716b7ea4L58-R58) [[3]](diffhunk://#diff-c9b929f74c933a55dee01f07769aa256d1dfa1e6c49b81eed601b997716b7ea4L68-R68)
* [`test/AST/ASTWalker.cpp`](diffhunk://#diff-2ac60083d677c83163c1174d7cf8d1ede2b23756b2af9db1831d7308ad28ed48L17-R26): Added `[[maybe_unused]]` attribute to the `node` parameter in the `beforeVisitNode`, `afterVisitNode`, and `visitLiteralExpr` methods.
* [`test/AST/Types/TypeVisitor.cpp`](diffhunk://#diff-284000238043b5be19b193b65188e33bf331ba7f11d538e6bb51aa5c5b0784d7L7-R22): Added `[[maybe_unused]]` attribute to the `type` parameter in the `visitIntTy`, `visitBoolTy`, `visitCharTy`, and `visitTypeBase` methods.