### PR TITLE
Feature: Generate GIL AssignStmt

### DIFF
--- a/include/GIL/Instructions/StoreInst.hpp
+++ b/include/GIL/Instructions/StoreInst.hpp
@@ -27,6 +27,10 @@ public:
         return inst->getKind() == InstKind::StoreInstKind;
     }
 
+    Type getResultType([[maybe_unused]] size_t index) const override
+    {
+        llvm_unreachable("StoreInst has no result type");
+    }
     size_t getResultCount() const override { return 0; }
     size_t getOperandCount() const override { return 2; }
     Operand getOperand([[maybe_unused]] size_t index) const override

--- a/include/GILGen/Context.hpp
+++ b/include/GILGen/Context.hpp
@@ -105,6 +105,11 @@ public:
         return insertTerminator(new (_arena)
                                     gil::ReturnInst(gil::Value::getEmptyKey()));
     }
+
+    gil::StoreInst *buildStore(gil::Value value, gil::Value ptr)
+    {
+        return insertInstruction(new (_arena) gil::StoreInst(value, ptr));
+    }
 };
 
 } // namespace glu::gilgen

--- a/lib/GILGen/GILGenExpr.hpp
+++ b/lib/GILGen/GILGenExpr.hpp
@@ -10,6 +10,30 @@ namespace glu::gilgen {
 
 using namespace glu::ast;
 
+struct GILGenLValue : public ASTVisitor<GILGenLValue, gil::Value> {
+    Context &ctx;
+
+    GILGenLValue(Context &ctx) : ctx(ctx) { }
+
+    gil::Value visitExprBase([[maybe_unused]] ExprBase *expr)
+    {
+        assert(false && "Unknown expression kind");
+        return gil::Value::getEmptyKey();
+    }
+
+    gil::Value visitRefExpr(RefExpr *expr)
+    {
+        // TODO: implement this function
+        return gil::Value::getEmptyKey();
+    }
+
+    gil::Value visitStructMemberExpr(StructMemberExpr *expr)
+    {
+        // TODO: implement this funciton
+        return gil::Value::getEmptyKey();
+    }
+};
+
 struct GILGenExpr : public ASTVisitor<GILGenExpr, gil::Value> {
     Context &ctx;
 
@@ -18,32 +42,6 @@ struct GILGenExpr : public ASTVisitor<GILGenExpr, gil::Value> {
     gil::Value visitExprBase([[maybe_unused]] ExprBase *expr)
     {
         assert(false && "Unknown expression kind");
-        return gil::Value::getEmptyKey();
-    }
-
-    gil::Value visitAsLValue(ExprBase *expr)
-    {
-        switch (expr->getKind()) {
-        case NodeKind::RefExprKind:
-            return visitRefExprAsLValue(llvm::cast<RefExpr>(expr));
-        case NodeKind::StructMemberExprKind:
-            return visitStructMemberExprAsLValue(
-                llvm::cast<StructMemberExpr>(expr)
-            );
-        default: assert(false && "Invalid expression for LValue");
-        }
-    }
-
-    gil::Value visitRefExprAsLValue(RefExpr *expr)
-    {
-        // TODO: search the variable in the current scope
-        return gil::Value::getEmptyKey();
-    }
-
-    gil::Value visitStructMemberExprAsLValue(StructMemberExpr *expr)
-    {
-        // gil::Value structValue = visitAsLValue(expr->getStructExpr());
-        // TODO: return ctx.buildStructFieldPtr();
         return gil::Value::getEmptyKey();
     }
 };

--- a/lib/GILGen/GILGenExpr.hpp
+++ b/lib/GILGen/GILGenExpr.hpp
@@ -14,6 +14,38 @@ struct GILGenExpr : public ASTVisitor<GILGenExpr, gil::Value> {
     Context &ctx;
 
     GILGenExpr(Context &ctx) : ctx(ctx) { }
+
+    gil::Value visitExprBase([[maybe_unused]] ExprBase *expr)
+    {
+        assert(false && "Unknown expression kind");
+        return gil::Value::getEmptyKey();
+    }
+
+    gil::Value visitAsLValue(ExprBase *expr)
+    {
+        switch (expr->getKind()) {
+        case NodeKind::RefExprKind:
+            return visitRefExprAsLValue(llvm::cast<RefExpr>(expr));
+        case NodeKind::StructMemberExprKind:
+            return visitStructMemberExprAsLValue(
+                llvm::cast<StructMemberExpr>(expr)
+            );
+        default: assert(false && "Invalid expression for LValue");
+        }
+    }
+
+    gil::Value visitRefExprAsLValue(RefExpr *expr)
+    {
+        // TODO: search the variable in the current scope
+        return gil::Value::getEmptyKey();
+    }
+
+    gil::Value visitStructMemberExprAsLValue(StructMemberExpr *expr)
+    {
+        // gil::Value structValue = visitAsLValue(expr->getStructExpr());
+        // TODO: return ctx.buildStructFieldPtr();
+        return gil::Value::getEmptyKey();
+    }
 };
 
 } // namespace glu::gilgen

--- a/lib/GILGen/GILGenExpr.hpp
+++ b/lib/GILGen/GILGenExpr.hpp
@@ -10,30 +10,6 @@ namespace glu::gilgen {
 
 using namespace glu::ast;
 
-struct GILGenLValue : public ASTVisitor<GILGenLValue, gil::Value> {
-    Context &ctx;
-
-    GILGenLValue(Context &ctx) : ctx(ctx) { }
-
-    gil::Value visitExprBase([[maybe_unused]] ExprBase *expr)
-    {
-        assert(false && "Unknown expression kind");
-        return gil::Value::getEmptyKey();
-    }
-
-    gil::Value visitRefExpr(RefExpr *expr)
-    {
-        // TODO: implement this function
-        return gil::Value::getEmptyKey();
-    }
-
-    gil::Value visitStructMemberExpr(StructMemberExpr *expr)
-    {
-        // TODO: implement this funciton
-        return gil::Value::getEmptyKey();
-    }
-};
-
 struct GILGenExpr : public ASTVisitor<GILGenExpr, gil::Value> {
     Context &ctx;
 

--- a/lib/GILGen/GILGenLValue.hpp
+++ b/lib/GILGen/GILGenLValue.hpp
@@ -1,0 +1,38 @@
+#ifndef GLU_GILGEN_GILGENLVALUE_HPP
+#define GLU_GILGEN_GILGENLVALUE_HPP
+
+#include "ASTVisitor.hpp"
+#include "Context.hpp"
+#include "Exprs.hpp"
+
+namespace glu::gilgen {
+
+using namespace glu::ast;
+
+struct GILGenLValue : public ASTVisitor<GILGenLValue, gil::Value> {
+    Context &ctx;
+
+    GILGenLValue(Context &ctx) : ctx(ctx) { }
+
+    gil::Value visitExprBase([[maybe_unused]] ExprBase *expr)
+    {
+        assert(false && "Unknown expression kind");
+        return gil::Value::getEmptyKey();
+    }
+
+    gil::Value visitRefExpr(RefExpr *expr)
+    {
+        // TODO: implement this function
+        return gil::Value::getEmptyKey();
+    }
+
+    gil::Value visitStructMemberExpr(StructMemberExpr *expr)
+    {
+        // TODO: implement this funciton
+        return gil::Value::getEmptyKey();
+    }
+};
+
+}
+
+#endif /* GLU_GILGEN_GILGENLVALUE_HPP */

--- a/lib/GILGen/GILGenStmt.cpp
+++ b/lib/GILGen/GILGenStmt.cpp
@@ -72,6 +72,14 @@ struct GILGenStmt : public ASTVisitor<GILGenStmt, void> {
         ctx.buildBr(scope->continueDestination);
         ctx.positionAtEnd(ctx.buildUnreachableBB());
     }
+
+    void visitAssignStmt(AssignStmt *stmt)
+    {
+        auto rhs = GILGenExpr(ctx).visit(stmt->getExprRight());
+        auto lhs = GILGenExpr(ctx).visitAsLValue(stmt->getExprLeft());
+
+        ctx.buildStore(rhs, lhs);
+    }
 };
 
 gil::Function *

--- a/lib/GILGen/GILGenStmt.cpp
+++ b/lib/GILGen/GILGenStmt.cpp
@@ -76,7 +76,7 @@ struct GILGenStmt : public ASTVisitor<GILGenStmt, void> {
     void visitAssignStmt(AssignStmt *stmt)
     {
         auto rhs = GILGenExpr(ctx).visit(stmt->getExprRight());
-        auto lhs = GILGenExpr(ctx).visitAsLValue(stmt->getExprLeft());
+        auto lhs = GILGenLValue(ctx).visit(stmt->getExprLeft());
 
         ctx.buildStore(rhs, lhs);
     }

--- a/lib/GILGen/GILGenStmt.cpp
+++ b/lib/GILGen/GILGenStmt.cpp
@@ -1,9 +1,9 @@
-#include "Context.hpp"
-#include "Scope.hpp"
-
 #include "ASTVisitor.hpp"
+#include "Context.hpp"
 #include "GILGen.hpp"
 #include "GILGenExpr.hpp"
+#include "GILGenLValue.hpp"
+#include "Scope.hpp"
 
 #include <llvm/ADT/SmallVector.h>
 


### PR DESCRIPTION
This pull request introduces several changes to the GIL (Generic Intermediate Language) codebase, focusing on the implementation of new functionalities and improvements in code organization. The most important changes include adding a new method to the `StoreInst` class, implementing a `buildStore` method in the `Context` class, and creating a new `GILGenLValue` structure.

### New functionalities and improvements:

* [`include/GIL/Instructions/StoreInst.hpp`](diffhunk://#diff-5f718fa083572d80aba9f99fd6035ef4e614d628e87da495a38d64d065e9fdddR30-R33): Added a `getResultType` method to the `StoreInst` class to indicate that it has no result type.
* [`include/GILGen/Context.hpp`](diffhunk://#diff-8ae0728cf00451f130fd9720882f406d8cdcc62b9792bdb6be946334c66be4d5R108-R112): Implemented a `buildStore` method in the `Context` class to insert a `StoreInst` instruction.
* [`lib/GILGen/GILGenExpr.hpp`](diffhunk://#diff-b9b199ff8a9f25bfd22499c9eafecdbf6cb71bad6dc79360b40a79c58c8c41b9R17-R22): Added a `visitExprBase` method to the `GILGenExpr` structure to handle unknown expression kinds.
* [`lib/GILGen/GILGenLValue.hpp`](diffhunk://#diff-9ff17e4d481131619dbd1c67fd9543863903e2575d91110686b816272add0a77R1-R38): Created a new `GILGenLValue` structure with methods to visit reference and struct member expressions.
* [`lib/GILGen/GILGenStmt.cpp`](diffhunk://#diff-c9b929f74c933a55dee01f07769aa256d1dfa1e6c49b81eed601b997716b7ea4R75-R82): Added a `visitAssignStmt` method to the `GILGenStmt` structure to handle assignment statements by generating store instructions.

### Code organization:

* [`lib/GILGen/GILGenStmt.cpp`](diffhunk://#diff-c9b929f74c933a55dee01f07769aa256d1dfa1e6c49b81eed601b997716b7ea4L1-R6): Reorganized includes to ensure necessary headers are included.

fix #298 