### PR TITLE
[GILGen] Feature: Generate GIL for Operator Expressions (Unary and Binary)

### DIFF
--- a/include/GIL/Instructions/BrInst.hpp
+++ b/include/GIL/Instructions/BrInst.hpp
@@ -2,6 +2,7 @@
 #define GLU_GIL_INSTRUCTIONS_BR_INST_HPP
 
 #include "TerminatorInst.hpp"
+#include <llvm/Support/TrailingObjects.h>
 
 namespace glu::gil {
 /// @class BrInst
@@ -10,25 +11,112 @@ namespace glu::gil {
 /// This instruction is a control flow terminator, meaning it marks the end of
 /// execution in a function. It does not produce any results and must always be
 /// the last instruction in a basic block.
-class BrInst : public TerminatorInst {
-    BasicBlock *value;
+///
+/// This instruction can also pass arguments to the destination basic block,
+/// supporting phi-like functionality through basic block arguments.
+class BrInst final : public TerminatorInst,
+                     private llvm::TrailingObjects<BrInst, Value> {
+
+    using TrailingArgs = llvm::TrailingObjects<BrInst, Value>;
+    friend TrailingArgs;
+
+    BasicBlock *destination;
+    unsigned _argsCount;
+
+    // Methods required by llvm::TrailingObjects to determine the number of
+    // trailing objects
+    size_t numTrailingObjects(typename TrailingArgs::OverloadToken<Value>) const
+    {
+        return _argsCount;
+    }
+
+private:
+    /// @brief Private constructor for the BrInst that takes trailing objects.
+    ///
+    /// @param destination The basic block to branch to.
+    /// @param args The arguments to pass to the destination block.
+    BrInst(BasicBlock *destination, llvm::ArrayRef<Value> args)
+        : TerminatorInst(InstKind::BrInstKind)
+        , destination(destination)
+        , _argsCount(args.size())
+    {
+        // Ensure the number of arguments matches the number of parameters in
+        // the destination block
+        assert(
+            destination->getArgumentCount() == _argsCount
+            && "Number of arguments must match number of parameters in the "
+               "destination block"
+        );
+
+        // Use uninitialized_copy for raw memory
+        std::uninitialized_copy(args.begin(), args.end(), getArgsPtr());
+    }
 
 public:
-    BrInst(BasicBlock *value)
-        : TerminatorInst(InstKind::BrInstKind), value(value)
+    /// @brief Static factory method to create a BrInst without arguments.
+    ///
+    /// @param arena The memory arena to allocate from.
+    /// @param destination The basic block to branch to.
+    static BrInst *
+    create(llvm::BumpPtrAllocator &arena, BasicBlock *destination)
     {
+        auto totalSize = totalSizeToAlloc<Value>(0);
+        void *mem = arena.Allocate(totalSize, alignof(BrInst));
+
+        return new (mem) BrInst(destination, {});
     }
+
+    /// @brief Static factory method to create a BrInst with arguments.
+    ///
+    /// @param arena The memory arena to allocate from.
+    /// @param destination The basic block to branch to.
+    /// @param args The arguments to pass to the destination block.
+    static BrInst *create(
+        llvm::BumpPtrAllocator &arena, BasicBlock *destination,
+        llvm::ArrayRef<Value> args
+    )
+    {
+        auto totalSize = totalSizeToAlloc<Value>(args.size());
+        void *mem = arena.Allocate(totalSize, alignof(BrInst));
+
+        return new (mem) BrInst(destination, args);
+    }
+
+    // Helper methods to access the trailing objects
+    Value *getArgsPtr() { return getTrailingObjects<Value>(); }
+    Value const *getArgsPtr() const { return getTrailingObjects<Value>(); }
+
+    BasicBlock *getDestination() const { return destination; }
+
+    llvm::ArrayRef<Value> getArgs() const
+    {
+        return llvm::ArrayRef<Value>(getArgsPtr(), _argsCount);
+    }
+
+    bool hasBranchArgs() const { return _argsCount > 0; }
 
     static bool classof(InstBase const *inst)
     {
         return inst->getKind() == InstKind::BrInstKind;
     }
 
-    size_t getOperandCount() const override { return 1; }
-    Operand getOperand([[maybe_unused]] size_t index) const override
+    size_t getOperandCount() const override
     {
-        assert(index == 0 && "Invalid operand index");
-        return value;
+        // 1 base operand (destination) + branch arguments
+        return 1 + _argsCount;
+    }
+
+    Operand getOperand(size_t index) const override
+    {
+        if (index == 0)
+            return destination;
+
+        // Handle arguments
+        if (index < 1 + _argsCount) {
+            return getArgsPtr()[index - 1];
+        }
+
+        assert(false && "Invalid operand index");
     }
 };
 

--- a/include/GIL/Instructions/BrInst.hpp
+++ b/include/GIL/Instructions/BrInst.hpp
@@ -53,27 +53,15 @@ private:
     }
 
 public:
-    /// @brief Static factory method to create a BrInst without arguments.
+    /// @brief Static factory method to create a BrInst with optional arguments.
     ///
     /// @param arena The memory arena to allocate from.
     /// @param destination The basic block to branch to.
-    static BrInst *
-    create(llvm::BumpPtrAllocator &arena, BasicBlock *destination)
-    {
-        auto totalSize = totalSizeToAlloc<Value>(0);
-        void *mem = arena.Allocate(totalSize, alignof(BrInst));
-
-        return new (mem) BrInst(destination, {});
-    }
-
-    /// @brief Static factory method to create a BrInst with arguments.
-    ///
-    /// @param arena The memory arena to allocate from.
-    /// @param destination The basic block to branch to.
-    /// @param args The arguments to pass to the destination block.
+    /// @param args The arguments to pass to the destination block (empty by
+    /// default).
     static BrInst *create(
         llvm::BumpPtrAllocator &arena, BasicBlock *destination,
-        llvm::ArrayRef<Value> args
+        llvm::ArrayRef<Value> args = {}
     )
     {
         auto totalSize = totalSizeToAlloc<Value>(args.size());
@@ -112,7 +100,7 @@ public:
             return destination;
 
         // Handle arguments
-        if (index < 1 + _argsCount) {
+        if (index - 1 < _argsCount) {
             return getArgsPtr()[index - 1];
         }
 

--- a/include/GIL/Instructions/CondBrInst.hpp
+++ b/include/GIL/Instructions/CondBrInst.hpp
@@ -79,38 +79,22 @@ private:
     }
 
 public:
-    /// @brief Static factory method to create a CondBrInst without arguments.
+    /// @brief Static factory method to create a CondBrInst with optional
+    /// arguments.
     ///
     /// @param arena The memory arena to allocate from.
     /// @param condition The condition value that determines which branch to
     /// take.
     /// @param thenBlock The basic block to branch to if the condition is true.
     /// @param elseBlock The basic block to branch to if the condition is false.
+    /// @param thenArgs The arguments to pass to the then block (empty by
+    /// default).
+    /// @param elseArgs The arguments to pass to the else block (empty by
+    /// default).
     static CondBrInst *create(
         llvm::BumpPtrAllocator &arena, Value condition, BasicBlock *thenBlock,
-        BasicBlock *elseBlock
-    )
-    {
-        auto totalSize = totalSizeToAlloc<Value, Value>(0, 0);
-        void *mem = arena.Allocate(totalSize, alignof(CondBrInst));
-
-        return new (mem) CondBrInst(condition, thenBlock, elseBlock, {}, {});
-    }
-
-    /// @brief Static factory method to create a CondBrInst with arguments for
-    /// both branches.
-    ///
-    /// @param arena The memory arena to allocate from.
-    /// @param condition The condition value that determines which branch to
-    /// take.
-    /// @param thenBlock The basic block to branch to if the condition is true.
-    /// @param elseBlock The basic block to branch to if the condition is false.
-    /// @param thenArgs The arguments to pass to the then block.
-    /// @param elseArgs The arguments to pass to the else block.
-    static CondBrInst *create(
-        llvm::BumpPtrAllocator &arena, Value condition, BasicBlock *thenBlock,
-        BasicBlock *elseBlock, llvm::ArrayRef<Value> thenArgs,
-        llvm::ArrayRef<Value> elseArgs
+        BasicBlock *elseBlock, llvm::ArrayRef<Value> thenArgs = {},
+        llvm::ArrayRef<Value> elseArgs = {}
     )
     {
         auto totalSize

--- a/include/GIL/Instructions/CondBrInst.hpp
+++ b/include/GIL/Instructions/CondBrInst.hpp
@@ -2,6 +2,7 @@
 #define GLU_GIL_INSTRUCTIONS_COND_BR_INST_HPP
 
 #include "TerminatorInst.hpp"
+#include <llvm/ADT/SmallVector.h>
 
 namespace glu::gil {
 /// @class CondBrInst
@@ -11,12 +12,24 @@ namespace glu::gil {
 /// of two possible successor basic blocks based on a given condition.
 /// If the condition evaluates to true, execution proceeds to the "then" block;
 /// otherwise, it proceeds to the "else" block. This instruction must always be
+/// the last instruction in a basic block.
+///
+/// This instruction can also pass arguments to the destination basic blocks,
+/// supporting phi-like functionality through basic block arguments.
 class CondBrInst : public TerminatorInst {
     Value condition;
     BasicBlock *thenBlock;
     BasicBlock *elseBlock;
+    llvm::SmallVector<Value, 2> thenArgs;
+    llvm::SmallVector<Value, 2> elseArgs;
 
 public:
+    /// @brief Constructs a CondBrInst without arguments.
+    ///
+    /// @param condition The condition value that determines which branch to
+    /// take.
+    /// @param thenBlock The basic block to branch to if the condition is true.
+    /// @param elseBlock The basic block to branch to if the condition is false.
     CondBrInst(Value condition, BasicBlock *thenBlock, BasicBlock *elseBlock)
         : TerminatorInst(InstKind::CondBrInstKind)
         , condition(condition)
@@ -25,13 +38,63 @@ public:
     {
     }
 
+    /// @brief Constructs a CondBrInst with arguments for the then and else
+    /// branches.
+    ///
+    /// @param condition The condition value that determines which branch to
+    /// take.
+    /// @param thenBlock The basic block to branch to if the condition is true.
+    /// @param elseBlock The basic block to branch to if the condition is false.
+    /// @param thenArgs The arguments to pass to the then block.
+    /// @param elseArgs The arguments to pass to the else block.
+    CondBrInst(
+        Value condition, BasicBlock *thenBlock, BasicBlock *elseBlock,
+        llvm::ArrayRef<Value> thenArgs, llvm::ArrayRef<Value> elseArgs
+    )
+        : TerminatorInst(InstKind::CondBrInstKind)
+        , condition(condition)
+        , thenBlock(thenBlock)
+        , elseBlock(elseBlock)
+        , thenArgs(thenArgs.begin(), thenArgs.end())
+        , elseArgs(elseArgs.begin(), elseArgs.end())
+    {
+        // Ensure the number of arguments matches the number of parameters in
+        // the destination blocks
+        assert(
+            thenBlock->getArgumentCount() == thenArgs.size()
+            && "Number of arguments must match number of parameters in the "
+               "then block"
+        );
+        assert(
+            elseBlock->getArgumentCount() == elseArgs.size()
+            && "Number of arguments must match number of parameters in the "
+               "else block"
+        );
+    }
+
+    Value getCondition() const { return condition; }
+    BasicBlock *getThenBlock() const { return thenBlock; }
+    BasicBlock *getElseBlock() const { return elseBlock; }
+    llvm::ArrayRef<Value> getThenArgs() const { return thenArgs; }
+    llvm::ArrayRef<Value> getElseArgs() const { return elseArgs; }
+
+    bool hasBranchArgs() const
+    {
+        return !thenArgs.empty() || !elseArgs.empty();
+    }
+
     static bool classof(InstBase const *inst)
     {
         return inst->getKind() == InstKind::CondBrInstKind;
     }
 
-    size_t getOperandCount() const override { return 3; }
-    Operand getOperand([[maybe_unused]] size_t index) const override
+    size_t getOperandCount() const override
+    {
+        // 3 base operands (condition, thenBlock, elseBlock) + branch arguments
+        return 3 + thenArgs.size() + elseArgs.size();
+    }
+
+    Operand getOperand(size_t index) const override
     {
         if (index == 0)
             return condition;
@@ -39,8 +102,18 @@ public:
             return thenBlock;
         if (index == 2)
             return elseBlock;
-        else
-            assert(false && "Invalid operand index");
+
+        // Handle then arguments
+        if (index < 3 + thenArgs.size()) {
+            return thenArgs[index - 3];
+        }
+
+        // Handle else arguments
+        if (index < 3 + thenArgs.size() + elseArgs.size()) {
+            return elseArgs[index - 3 - thenArgs.size()];
+        }
+
+        assert(false && "Invalid operand index");
     }
 };
 

--- a/include/GIL/Instructions/CondBrInst.hpp
+++ b/include/GIL/Instructions/CondBrInst.hpp
@@ -174,12 +174,12 @@ public:
             return elseBlock;
 
         // Handle then arguments
-        if (index < 3 + _thenArgsCount) {
+        if (index - 3 < _thenArgsCount) {
             return getThenArgsPtr()[index - 3];
         }
 
         // Handle else arguments
-        if (index < 3 + _thenArgsCount + _elseArgsCount) {
+        if (index - 3 - _thenArgsCount < _elseArgsCount) {
             return getElseArgsPtr()[index - 3 - _thenArgsCount];
         }
 

--- a/include/GILGen/Context.hpp
+++ b/include/GILGen/Context.hpp
@@ -184,6 +184,15 @@ public:
                                     gil::CondBrInst(cond, thenBB, elseBB));
     }
 
+    gil::CondBrInst *buildCondBr(
+        gil::Value cond, gil::BasicBlock *thenBB, gil::BasicBlock *elseBB,
+        llvm::ArrayRef<gil::Value> thenArgs, llvm::ArrayRef<gil::Value> elseArgs
+    )
+    {
+        return insertTerminator(new (_arena
+        ) gil::CondBrInst(cond, thenBB, elseBB, thenArgs, elseArgs));
+    }
+
     gil::CallInst *
     buildCall(std::string const &opName, llvm::ArrayRef<gil::Value> args)
     {

--- a/include/GILGen/Context.hpp
+++ b/include/GILGen/Context.hpp
@@ -183,6 +183,20 @@ public:
         return insertTerminator(new (_arena)
                                     gil::CondBrInst(cond, thenBB, elseBB));
     }
+
+    gil::CallInst *
+    buildCall(std::string const &opName, llvm::ArrayRef<gil::Value> args)
+    {
+        // Create a Function* with the operator name (prefixed with @)
+        auto *func = new (_arena) gil::Function(opName, nullptr);
+        return insertInstruction(new (_arena) gil::CallInst(func, args));
+    }
+
+    gil::CallInst *
+    buildCall(gil::Value functionPtr, llvm::ArrayRef<gil::Value> args)
+    {
+        return insertInstruction(new (_arena) gil::CallInst(functionPtr, args));
+    }
 };
 
 } // namespace glu::gilgen

--- a/include/GILGen/Context.hpp
+++ b/include/GILGen/Context.hpp
@@ -180,8 +180,9 @@ public:
         gil::Value cond, gil::BasicBlock *thenBB, gil::BasicBlock *elseBB
     )
     {
-        return insertTerminator(new (_arena)
-                                    gil::CondBrInst(cond, thenBB, elseBB));
+        return insertTerminator(
+            gil::CondBrInst::create(_arena, cond, thenBB, elseBB)
+        );
     }
 
     gil::CondBrInst *buildCondBr(
@@ -189,8 +190,11 @@ public:
         llvm::ArrayRef<gil::Value> thenArgs, llvm::ArrayRef<gil::Value> elseArgs
     )
     {
-        return insertTerminator(new (_arena
-        ) gil::CondBrInst(cond, thenBB, elseBB, thenArgs, elseArgs));
+        return insertTerminator(
+            gil::CondBrInst::create(
+                _arena, cond, thenBB, elseBB, thenArgs, elseArgs
+            )
+        );
     }
 
     gil::CallInst *

--- a/include/GILGen/Context.hpp
+++ b/include/GILGen/Context.hpp
@@ -98,7 +98,12 @@ public:
 
     gil::BrInst *buildBr(gil::BasicBlock *dest)
     {
-        return insertTerminator(new (_arena) gil::BrInst(dest));
+        return insertTerminator(gil::BrInst::create(_arena, dest));
+    }
+
+    gil::BrInst *buildBr(gil::BasicBlock *dest, llvm::ArrayRef<gil::Value> args)
+    {
+        return insertTerminator(gil::BrInst::create(_arena, dest, args));
     }
 
     gil::UnreachableInst *buildUnreachable()

--- a/include/GILGen/Context.hpp
+++ b/include/GILGen/Context.hpp
@@ -187,7 +187,7 @@ public:
     gil::CallInst *
     buildCall(std::string const &opName, llvm::ArrayRef<gil::Value> args)
     {
-        // Create a Function* with the operator name (prefixed with @)
+        // Create a Function* with the operator name
         auto *func = new (_arena) gil::Function(opName, nullptr);
         return insertInstruction(new (_arena) gil::CallInst(func, args));
     }
@@ -196,6 +196,17 @@ public:
     buildCall(gil::Value functionPtr, llvm::ArrayRef<gil::Value> args)
     {
         return insertInstruction(new (_arena) gil::CallInst(functionPtr, args));
+    }
+
+    gil::CallInst *
+    buildCall(ast::FunctionDecl *func, llvm::ArrayRef<gil::Value> args)
+    {
+        // When sema is implemented, it will provide the resolved function
+        // declaration For now, we create a function with the name from the
+        // declaration
+        auto *gilFunc = new (_arena)
+            gil::Function(func->getName().str(), func->getType());
+        return insertInstruction(new (_arena) gil::CallInst(gilFunc, args));
     }
 };
 

--- a/lib/GILGen/GILGenExpr.hpp
+++ b/lib/GILGen/GILGenExpr.hpp
@@ -178,13 +178,14 @@ struct GILGenExpr : public ASTVisitor<GILGenExpr, gil::Value> {
         gil::Value leftValue = visit(expr->getLeftOperand());
         gil::Value rightValue = visit(expr->getRightOperand());
 
-        // Get the token for the operator
-        Token opToken = expr->getOperator();
-
         // Get the lexeme directly from the token
-        std::string opName = opToken.getLexeme().str();
+        std::string opName = expr->getOperator().getLexeme().str();
 
-        // Create a call to the appropriate operator function
+        // TODO: When sema is implemented, this should be replaced with:
+        // ast::FunctionDecl *opFunc = expr->getOperatorFunction();
+        // return ctx.buildCall(opFunc, args);
+
+        // For now, create a call to the appropriate operator function by name
         llvm::SmallVector<gil::Value, 2> args { leftValue, rightValue };
         return ctx.buildCall(opName, args)->getResult(0);
     }
@@ -196,13 +197,14 @@ struct GILGenExpr : public ASTVisitor<GILGenExpr, gil::Value> {
         // Generate code for the operand
         gil::Value operandValue = visit(expr->getOperand());
 
-        // Get the token for the operator
-        Token opToken = expr->getOperator();
-
         // Get the lexeme directly from the token
-        std::string opName = opToken.getLexeme().str();
+        std::string opName = expr->getOperator().getLexeme().str();
 
-        // Create a call to the appropriate operator function
+        // TODO: When sema is implemented, this should be replaced with:
+        // ast::FunctionDecl *opFunc = expr->getOperatorFunction();
+        // return ctx.buildCall(opFunc, args);
+
+        // For now, create a call to the appropriate operator function by name
         llvm::SmallVector<gil::Value, 1> args { operandValue };
         return ctx.buildCall(opName, args)->getResult(0);
     }


### PR DESCRIPTION
This pull request introduces new functionality to handle operator calls in the GILGen module. The most important changes include adding methods to build call instructions in the `Context` class and implementing visitor methods for binary and unary operator expressions in the `GILGenExpr` class.

### Enhancements to `Context` class:

* Added `buildCall` methods to create call instructions for both operator names and function pointers. (`include/GILGen/Context.hpp`)

### Enhancements to `GILGenExpr` class:

* Implemented `visitBinaryOpExpr` method to generate code for binary operator expressions and create calls to the appropriate operator functions. (`lib/GILGen/GILGenExpr.hpp`)
* Implemented `visitUnaryOpExpr` method to handle unary operator expressions, including special handling for certain operators to avoid conflicts. (`lib/GILGen/GILGenExpr.hpp`)

fix #274