### PR TITLE
[GILGen] Feature: Generate GIL for literals

### DIFF
--- a/include/AST/Expr/LiteralExpr.hpp
+++ b/include/AST/Expr/LiteralExpr.hpp
@@ -12,8 +12,11 @@ namespace glu::ast {
 /// @brief Represents a literal expression in the AST (e.g., 42, 3.14, "abc",
 /// true).
 class LiteralExpr : public ExprBase {
+public:
     using LiteralValue
         = std::variant<llvm::APInt, llvm::APFloat, llvm::StringRef, bool>;
+
+private:
     LiteralValue _value;
 
 public:

--- a/include/GILGen/Context.hpp
+++ b/include/GILGen/Context.hpp
@@ -226,6 +226,38 @@ public:
             gil::Function(func->getName().str(), func->getType());
         return insertInstruction(new (_arena) gil::CallInst(gilFunc, args));
     }
+
+    /// Creates an integer literal instruction
+    gil::IntegerLiteralInst *
+    buildIntegerLiteral(gil::Type type, llvm::APInt value)
+    {
+        return insertInstruction(new (_arena)
+                                     gil::IntegerLiteralInst(type, value));
+    }
+
+    /// Creates a floating-point literal instruction
+    gil::FloatLiteralInst *
+    buildFloatLiteral(gil::Type type, llvm::APFloat value)
+    {
+        return insertInstruction(new (_arena) gil::FloatLiteralInst(type, value)
+        );
+    }
+
+    /// Creates a boolean literal instruction (represented as an integer literal
+    /// with value 0 or 1)
+    gil::IntegerLiteralInst *buildBoolLiteral(gil::Type type, bool value)
+    {
+        llvm::APInt boolValue(1, value ? 1 : 0);
+        return buildIntegerLiteral(type, boolValue);
+    }
+
+    /// Creates a string literal instruction
+    gil::StringLiteralInst *
+    buildStringLiteral(gil::Type type, llvm::StringRef value)
+    {
+        return insertInstruction(new (_arena)
+                                     gil::StringLiteralInst(type, value.str()));
+    }
 };
 
 } // namespace glu::gilgen

--- a/lib/GILGen/GILGenExpr.hpp
+++ b/lib/GILGen/GILGenExpr.hpp
@@ -2,6 +2,7 @@
 #define GLU_GILGEN_GILGENEXPR_HPP
 
 #include "Context.hpp"
+#include "LiteralVisitor.hpp"
 
 #include "ASTVisitor.hpp"
 #include "Exprs.hpp"
@@ -204,6 +205,16 @@ struct GILGenExpr : public ASTVisitor<GILGenExpr, gil::Value> {
         // For now, create a call to the appropriate operator function by name
         llvm::SmallVector<gil::Value, 1> args { operandValue };
         return ctx.buildCall(opName, args)->getResult(0);
+    }
+
+    gil::Value visitLiteralExpr(LiteralExpr *expr)
+    {
+        // Get the literal value and type
+        auto literalValue = expr->getValue();
+        auto type = ctx.translateType(expr->getType());
+
+        // Use the LiteralVisitor to generate the appropriate GIL instruction
+        return LiteralVisitor(ctx, type).visit(literalValue);
     }
 };
 

--- a/lib/GILGen/LiteralVisitor.hpp
+++ b/lib/GILGen/LiteralVisitor.hpp
@@ -1,0 +1,96 @@
+#ifndef GLU_GILGEN_LITERALVISITOR_HPP
+#define GLU_GILGEN_LITERALVISITOR_HPP
+
+#include "Context.hpp"
+#include <llvm/ADT/APFloat.h>
+#include <llvm/ADT/APInt.h>
+#include <llvm/ADT/StringRef.h>
+#include <variant>
+
+namespace glu::gilgen {
+
+///
+/// @class LiteralVisitor
+/// @brief Visitor for converting literal values into GIL instructions
+///
+/// This visitor is used to generate GIL instructions for different types of
+/// literals. It follows the same visitor pattern as other visitors in the
+/// project.
+///
+class LiteralVisitor {
+    Context &_ctx;
+    gil::Type _type;
+
+public:
+    ///
+    /// @brief Construct a new Literal Visitor
+    ///
+    /// @param ctx Context in which to build instructions
+    /// @param type GIL type of the literal
+    ///
+    LiteralVisitor(Context &ctx, gil::Type type) : _ctx(ctx), _type(type) { }
+
+    ///
+    /// @brief Visit a literal value to generate appropriate GIL instructions
+    ///
+    /// @param value The literal value as a variant
+    /// @return gil::Value The resulting GIL value
+    ///
+    gil::Value visit(
+        std::variant<llvm::APInt, llvm::APFloat, llvm::StringRef, bool> const
+            &value
+    )
+    {
+        return std::visit(
+            [this](auto const &v) { return this->visit(v); }, value
+        );
+    }
+
+    ///
+    /// @brief Handle integer literals
+    ///
+    /// @param value The integer value
+    /// @return gil::Value The resulting GIL value
+    ///
+    gil::Value visit(llvm::APInt const &value)
+    {
+        return _ctx.buildIntegerLiteral(_type, value)->getResult(0);
+    }
+
+    ///
+    /// @brief Handle floating-point literals
+    ///
+    /// @param value The floating-point value
+    /// @return gil::Value The resulting GIL value
+    ///
+    gil::Value visit(llvm::APFloat const &value)
+    {
+        return _ctx.buildFloatLiteral(_type, value)->getResult(0);
+    }
+
+    ///
+    /// @brief Handle boolean literals
+    ///
+    /// @param value The boolean value
+    /// @return gil::Value The resulting GIL value
+    ///
+    gil::Value visit(bool value)
+    {
+        return _ctx.buildBoolLiteral(_type, value)->getResult(0);
+    }
+
+    ///
+    /// @brief Handle string literals
+    ///
+    /// @param value The string value
+    /// @return gil::Value The resulting GIL value
+    ///
+    gil::Value visit(llvm::StringRef value)
+    {
+        return _ctx.buildStringLiteral(_type, value)->getResult(0);
+    }
+};
+
+} // namespace glu::gilgen
+
+#endif // GLU_GILGEN_LITERALVISITOR_HPP

--- a/lib/GILGen/LiteralVisitor.hpp
+++ b/lib/GILGen/LiteralVisitor.hpp
@@ -36,10 +36,7 @@ public:
     /// @param value The literal value as a variant
     /// @return gil::Value The resulting GIL value
     ///
-    gil::Value visit(
-        std::variant<llvm::APInt, llvm::APFloat, llvm::StringRef, bool> const
-            &value
-    )
+    gil::Value visit(ast::LiteralExpr::LiteralValue const &value)
     {
         return std::visit(
             [this](auto const &v) { return this->visit(v); }, value


### PR DESCRIPTION
This pull request introduces new functionality to handle literal values within the GIL (Generic Intermediate Language) generation process. The most important changes include the addition of methods to create various types of literal instructions and the implementation of a `LiteralVisitor` class to encapsulate the logic for these literals.

New functionality for handling literals:

* [`include/GILGen/Context.hpp`](diffhunk://#diff-8ae0728cf00451f130fd9720882f406d8cdcc62b9792bdb6be946334c66be4d5R229-R260): Added methods to create integer, floating-point, boolean, and string literal instructions.
* [`lib/GILGen/GILGenExpr.hpp`](diffhunk://#diff-b9b199ff8a9f25bfd22499c9eafecdbf6cb71bad6dc79360b40a79c58c8c41b9R5): Included the `LiteralVisitor` header and added a `visitLiteralExpr` method to handle literal expressions using the `LiteralVisitor`. [[1]](diffhunk://#diff-b9b199ff8a9f25bfd22499c9eafecdbf6cb71bad6dc79360b40a79c58c8c41b9R5) [[2]](diffhunk://#diff-b9b199ff8a9f25bfd22499c9eafecdbf6cb71bad6dc79360b40a79c58c8c41b9R209-R218)

Implementation of `LiteralVisitor`:

* [`lib/GILGen/LiteralVisitor.hpp`](diffhunk://#diff-6456e1df063d9f35b7aa55579918768b5e3e905b1dafcaf3e4c75305b9c26447R1-R96): Created a new `LiteralVisitor` class to convert different types of literal values into corresponding GIL instructions. This class uses the visitor pattern to handle integer, floating-point, boolean, and string literals.

fix #271