### PR TITLE
[DevOps] CI: fix Linter action

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,30 +18,11 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh 20
 
-      - name: Find .cpp and .hpp files in lib, include, and tools
-        id: find_files
+      - name: Find source files
+        id: files
         run: |
           find lib include tools \( -name '*.cpp' -o -name '*.hpp' \) > files.txt
 
-      - name: Check clang-format and show diffs
+      - name: Run clang-format check
         run: |
-          failed=0
-          while IFS= read -r file; do
-            # Skip if the file doesn't exist (just in case)
-            [ -f "$file" ] || continue
-
-            # Show diff if there are changes
-            clang-format-20 "$file" | diff -u "$file" - > /tmp/clang-format-diff.txt || true
-            if [ -s /tmp/clang-format-diff.txt ]; then
-              echo "Formatting issues in $file:"
-              cat /tmp/clang-format-diff.txt
-              failed=1
-            fi
-          done < files.txt
-
-          if [ "$failed" -eq 1 ]; then
-            echo "Some files are not correctly formatted. See the diffs above."
-            exit 1
-          else
-            echo "All files are properly formatted."
-          fi
+          xargs -a files.txt clang-format-20 --dry-run --Werror

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,24 +14,9 @@ jobs:
 
       - name: Install clang-format-20
         run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh 20
-
-      - name: Debug - List clang-format binaries
-        run: |
-          which clang-format-20 || true
-          which clang-format || true
-          ls -l /usr/bin/clang-format*
-
-      - name: Fallback symlink if needed
-        run: |
-          if ! command -v clang-format-20; then
-            sudo ln -sf $(command -v clang-format) /usr/bin/clang-format-20
-          fi
-
-      - name: Check clang-format version
-        run: clang-format-20 --version
+          sudo apt update
+          sudo apt install -y clang-format-20
+          clang-format-20 --version
 
       - name: Find source files
         id: files

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,6 +18,21 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh 20
 
+      - name: Debug - List clang-format binaries
+        run: |
+          which clang-format-20 || true
+          which clang-format || true
+          ls -l /usr/bin/clang-format*
+
+      - name: Fallback symlink if needed
+        run: |
+          if ! command -v clang-format-20; then
+            sudo ln -sf $(command -v clang-format) /usr/bin/clang-format-20
+          fi
+
+      - name: Check clang-format version
+        run: clang-format-20 --version
+
       - name: Find source files
         id: files
         run: |

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,6 +14,9 @@ jobs:
 
       - name: Install clang-format-20
         run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 20
           sudo apt update
           sudo apt install -y clang-format-20
           clang-format-20 --version

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -5,19 +5,43 @@ on:
   push:
 
 jobs:
-  run_clang-format:
-    name: Lint the codebase with clang-format
+  clang-format-check:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        path:
-          - 'lib'
-          - 'include'
-          - 'tools'
+
     steps:
-      - uses: actions/checkout@v4
-      - name: Run clang-format style check for C/C++/ programs
-        uses: jidicula/clang-format-action@v4.15.0
-        with:
-          clang-format-version: '20'
-          check-path: ${{ matrix.path }}
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install clang-format-20
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 20
+
+      - name: Find .cpp and .hpp files in lib, include, and tools
+        id: find_files
+        run: |
+          find lib include tools \( -name '*.cpp' -o -name '*.hpp' \) > files.txt
+
+      - name: Check clang-format and show diffs
+        run: |
+          failed=0
+          while IFS= read -r file; do
+            # Skip if the file doesn't exist (just in case)
+            [ -f "$file" ] || continue
+
+            # Show diff if there are changes
+            clang-format-20 "$file" | diff -u "$file" - > /tmp/clang-format-diff.txt || true
+            if [ -s /tmp/clang-format-diff.txt ]; then
+              echo "Formatting issues in $file:"
+              cat /tmp/clang-format-diff.txt
+              failed=1
+            fi
+          done < files.txt
+
+          if [ "$failed" -eq 1 ]; then
+            echo "Some files are not correctly formatted. See the diffs above."
+            exit 1
+          else
+            echo "All files are properly formatted."
+          fi

--- a/include/GIL/Instructions/StructDestructureInst.hpp
+++ b/include/GIL/Instructions/StructDestructureInst.hpp
@@ -51,9 +51,9 @@ public:
     /// @brief Gets the number of results (equal to number of struct fields).
     size_t getResultCount() const override
     {
-        auto structTy
-            = llvm::cast<glu::types::StructTy>(_structValue.getType().getType()
-            );
+        auto structTy = llvm::cast<glu::types::StructTy>(
+            _structValue.getType().getType()
+        );
         return structTy->getFieldCount();
     }
 

--- a/include/GILGen/Context.hpp
+++ b/include/GILGen/Context.hpp
@@ -144,26 +144,26 @@ public:
 
     gil::BitcastInst *buildBitcast(gil::Type destType, gil::Value value)
     {
-        return insertInstruction(new (_arena) gil::BitcastInst(destType, value)
-        );
+        return insertInstruction(new (_arena)
+                                     gil::BitcastInst(destType, value));
     }
 
     gil::IntTruncInst *buildIntTrunc(gil::Type destType, gil::Value value)
     {
-        return insertInstruction(new (_arena) gil::IntTruncInst(destType, value)
-        );
+        return insertInstruction(new (_arena)
+                                     gil::IntTruncInst(destType, value));
     }
 
     gil::IntZextInst *buildIntZext(gil::Type destType, gil::Value value)
     {
-        return insertInstruction(new (_arena) gil::IntZextInst(destType, value)
-        );
+        return insertInstruction(new (_arena)
+                                     gil::IntZextInst(destType, value));
     }
 
     gil::IntSextInst *buildIntSext(gil::Type destType, gil::Value value)
     {
-        return insertInstruction(new (_arena) gil::IntSextInst(destType, value)
-        );
+        return insertInstruction(new (_arena)
+                                     gil::IntSextInst(destType, value));
     }
 
     gil::FloatTruncInst *buildFloatTrunc(gil::Type destType, gil::Value value)
@@ -174,8 +174,8 @@ public:
 
     gil::FloatExtInst *buildFloatExt(gil::Type destType, gil::Value value)
     {
-        return insertInstruction(new (_arena) gil::FloatExtInst(destType, value)
-        );
+        return insertInstruction(new (_arena)
+                                     gil::FloatExtInst(destType, value));
     }
 
     /// Converts an AST type to a GIL type

--- a/lib/Sema/CSWalker.cpp
+++ b/lib/Sema/CSWalker.cpp
@@ -103,9 +103,10 @@ public:
     void postVisitReturnStmt(glu::ast::ReturnStmt *node)
     {
         auto *returnType = node->getReturnExpr()->getType();
-        auto *expectedReturnType
-            = _cs.getScopeTable()->getFunctionDecl()->getType()->getReturnType(
-            );
+        auto *expectedReturnType = _cs.getScopeTable()
+                                       ->getFunctionDecl()
+                                       ->getType()
+                                       ->getReturnType();
 
         // If the function is void, we don't need to constrain the return
         // type
@@ -114,9 +115,11 @@ public:
             return;
         }
 
-        _cs.addConstraint(Constraint::createConversion(
-            _cs.getAllocator(), returnType, expectedReturnType, node
-        ));
+        _cs.addConstraint(
+            Constraint::createConversion(
+                _cs.getAllocator(), returnType, expectedReturnType, node
+            )
+        );
     }
 };
 


### PR DESCRIPTION
As I noticed earlier, the CI was giving me errors whereas my clang-format was telling me there were no errors (either from my editor or even when I ran clang-format myself).

After some research, I simply noticed that what we were using for the action didn't support the `-style=file` parameter as shown here: https://github.com/jidicula/clang-format-action/issues/156

So I created our own action (and strangely enough, the action gives me the same results as locally).