### PR TITLE
Feature: ability to print nodes within LLDB

### DIFF
--- a/include/AST/ASTNode.hpp
+++ b/include/AST/ASTNode.hpp
@@ -69,7 +69,9 @@ public:
     /// @return The module in which the current node is declared.
     ModuleDecl *getModule();
 
-    void debugPrint(llvm::raw_ostream &out = llvm::outs());
+    void print(llvm::raw_ostream &out);
+
+    void debugPrint();
 };
 
 /// @brief Replace a child node in its parent node

--- a/include/AST/ASTNode.hpp
+++ b/include/AST/ASTNode.hpp
@@ -69,9 +69,14 @@ public:
     /// @return The module in which the current node is declared.
     ModuleDecl *getModule();
 
+    /// @brief Print a human-readable representation of this node to
+    /// an output stream, when --print-ast is enabled.
+    /// @param out The output stream to print to.
     void print(llvm::raw_ostream &out);
 
-    void debugPrint();
+    /// @brief Print a human-readable representation of this node to
+    /// standard output, for debugging purposes.
+    void print();
 };
 
 /// @brief Replace a child node in its parent node

--- a/include/AST/Types/TypeBase.hpp
+++ b/include/AST/Types/TypeBase.hpp
@@ -79,6 +79,10 @@ public:
     /// @return Returns the hash value of the type
     unsigned hash() const;
 
+    /// @brief Prints a human-readable representation of the type to stdout
+    /// for debugging purposes (for use in lldb)
+    void print();
+
     /// @brief Get the canonical type for this type
     /// @param context The AST context to use for transformation
     /// @return The canonical version of this type

--- a/include/GIL/Function.hpp
+++ b/include/GIL/Function.hpp
@@ -114,6 +114,10 @@ public:
     glu::ast::FunctionDecl *getDecl() const { return _decl; }
 
     void setDecl(glu::ast::FunctionDecl *decl) { _decl = decl; }
+
+    /// @brief Print a human-readable representation of this function to
+    /// standard output, for debugging purposes.
+    void print();
 };
 
 } // end namespace glu::gil

--- a/include/GIL/Global.hpp
+++ b/include/GIL/Global.hpp
@@ -90,6 +90,10 @@ public:
 
     glu::ast::VarLetDecl *getDecl() const { return _decl; }
     void setDecl(glu::ast::VarLetDecl *decl) { _decl = decl; }
+
+    /// @brief Print a human-readable representation of this function to
+    /// standard output, for debugging purposes.
+    void print();
 };
 
 } // end namespace glu::gil

--- a/include/GIL/Instructions/InstBase.hpp
+++ b/include/GIL/Instructions/InstBase.hpp
@@ -345,6 +345,10 @@ public:
     /// @brief Get the source location of this instruction.
     /// @return The source location of this instruction.
     SourceLocation getLocation() const { return _loc; }
+
+    /// @brief Print a human-readable representation of this instruction to
+    /// standard output, for debugging purposes.
+    void print();
 };
 
 } // end namespace glu::gil

--- a/include/GIL/Module.hpp
+++ b/include/GIL/Module.hpp
@@ -84,6 +84,10 @@ public:
 
     /// @brief clears the functions list
     void clearFunctions() { _functions.clear(); };
+
+    /// @brief Print a human-readable representation of this module to
+    /// standard output, for debugging purposes.
+    void print();
 };
 
 }

--- a/lib/ASTPrinter/ASTPrinter.cpp
+++ b/lib/ASTPrinter/ASTPrinter.cpp
@@ -333,7 +333,7 @@ void ASTNode::print(llvm::raw_ostream &out)
 // For use in LLDB:
 // Those must be out-of-line, otherwise they're optimized away
 
-void ASTNode::debugPrint()
+void ASTNode::print()
 {
     print(llvm::outs());
 }

--- a/lib/ASTPrinter/ASTPrinter.cpp
+++ b/lib/ASTPrinter/ASTPrinter.cpp
@@ -335,12 +335,12 @@ void ASTNode::print(llvm::raw_ostream &out)
 
 void ASTNode::debugPrint()
 {
-    print(llvm::errs());
+    print(llvm::outs());
 }
 
 } // namespace glu::ast
 
 void glu::types::TypeBase::print()
 {
-    llvm::errs() << glu::ast::TypePrinter().visit(this) << "\n";
+    llvm::outs() << glu::ast::TypePrinter().visit(this) << "\n";
 }

--- a/lib/ASTPrinter/ASTPrinter.cpp
+++ b/lib/ASTPrinter/ASTPrinter.cpp
@@ -325,10 +325,22 @@ public:
     }
 };
 
-void ASTNode::debugPrint(llvm::raw_ostream &out)
+void ASTNode::print(llvm::raw_ostream &out)
 {
-    return ASTPrinter(getModule()->getSourceManager(), out)
-        .visit(const_cast<ASTNode *>(this));
+    ASTPrinter(getModule()->getSourceManager(), out).visit(this);
+}
+
+// For use in LLDB:
+// Those must be out-of-line, otherwise they're optimized away
+
+void ASTNode::debugPrint()
+{
+    print(llvm::errs());
 }
 
 } // namespace glu::ast
+
+void glu::types::TypeBase::print()
+{
+    llvm::errs() << glu::ast::TypePrinter().visit(this) << "\n";
+}

--- a/lib/GIL/GILPrinter.cpp
+++ b/lib/GIL/GILPrinter.cpp
@@ -233,4 +233,60 @@ void GILPrinter::printType(types::TypeBase *type)
     }
 }
 
+// Convenience methods to print directly to stdout
+// For use in lldb
+// These are designed to be resilient (we might be in an invalid state)
+
+void InstBase::print()
+{
+    SourceManager *sm = nullptr;
+    if (auto *bb = this->getParent()) {
+        if (auto *func = bb->getParent()) {
+            if (auto *decl = func->getDecl()) {
+                if (auto *mod = decl->getModule()) {
+                    sm = mod->getSourceManager();
+                }
+            }
+        }
+    }
+    GILPrinter(sm).visit(this);
+}
+
+void Function::print()
+{
+    SourceManager *sm = nullptr;
+    if (auto *decl = this->getDecl()) {
+        if (auto *mod = decl->getModule()) {
+            sm = mod->getSourceManager();
+        }
+    }
+    GILPrinter(sm).visit(this);
+}
+
+void Global::print()
+{
+    SourceManager *sm = nullptr;
+    if (auto *decl = this->getDecl()) {
+        if (auto *mod = decl->getModule()) {
+            sm = mod->getSourceManager();
+        }
+    }
+    GILPrinter(sm).visit(this);
+}
+
+void Module::print()
+{
+    SourceManager *sm = nullptr;
+    for (auto &fn : this->getFunctions()) {
+        if (fn.getDecl() == nullptr) {
+            continue;
+        }
+        if (auto *mod = fn.getDecl()->getModule()) {
+            sm = mod->getSourceManager();
+            break;
+        }
+    }
+    GILPrinter(sm).visit(this);
+}
+
 } // end namespace glu::gil

--- a/tools/gluc/sources/main.cpp
+++ b/tools/gluc/sources/main.cpp
@@ -266,7 +266,7 @@ int main(int argc, char **argv)
             }
 
             if (PrintASTGen) {
-                ast->debugPrint(out);
+                ast->print(out);
                 continue;
             }
 
@@ -274,7 +274,7 @@ int main(int argc, char **argv)
             sema::constrainAST(ast, diagManager, ImportDirs);
 
             if (PrintAST) {
-                ast->debugPrint(out);
+                ast->print(out);
                 continue;
             }
 


### PR DESCRIPTION
Debugging gluc is annoying without the ability to easily see what node we're looking at.
It is now easy to just do `p node->print()` in LLDB and see the output in the terminal

> [!NOTE]  
> Because these functions are only used in LLDB and not used in the project, they can't be inline in the .hpp or they will never be compiled and won't work
> Also, we can't use default arguments as those don't work in LLDB