### PR TITLE
Feature: Inline functions

### DIFF
--- a/include/AST/Attributes.def
+++ b/include/AST/Attributes.def
@@ -5,5 +5,6 @@
 
 ATTRIBUTE_KIND(NoMangling, "no_mangling", FunctionAttachment)
 ATTRIBUTE_KIND(CVariadic, "c_variadic", FunctionPrototypeAttachment)
+ATTRIBUTE_KIND(Inline, "inline", FunctionDefinitionAttachment)
 
 #undef ATTRIBUTE_KIND

--- a/include/GIL/Module.hpp
+++ b/include/GIL/Module.hpp
@@ -74,6 +74,8 @@ public:
     /// @return Returns a ref to the globals list
     GlobalListType &getGlobals() { return _globals; }
 
+    gil::Function *getFunctionByDecl(ast::FunctionDecl *decl);
+
     /// @brief Setter for the module import name
     /// @param name A string representing the new module import name
     void setImportName(llvm::StringRef name) { _importName = name; }

--- a/include/GILGen/GILGen.hpp
+++ b/include/GILGen/GILGen.hpp
@@ -7,7 +7,17 @@
 
 namespace glu::gilgen {
 
-struct GlobalContext;
+/// @brief The context around the GIL module being generated.
+struct GlobalContext {
+    gil::Module *module;
+    llvm::BumpPtrAllocator &arena;
+    llvm::DenseSet<ast::FunctionDecl *> _inlinableFunctions;
+
+    GlobalContext(gil::Module *module, llvm::BumpPtrAllocator &arena)
+        : module(module), arena(arena)
+    {
+    }
+};
 
 class GILGen {
 public:
@@ -25,10 +35,6 @@ public:
 
     gil::Function *generateFunction(
         gil::Module *module, ast::FunctionDecl *decl, GlobalContext &globalCtx
-    );
-
-    gil::Function *_generateFunctionTest(
-        ast::FunctionDecl *decl, llvm::BumpPtrAllocator &arena
     );
 
     /// @brief Generate a GIL module from an AST module declaration

--- a/include/GILGen/GILGen.hpp
+++ b/include/GILGen/GILGen.hpp
@@ -7,6 +7,8 @@
 
 namespace glu::gilgen {
 
+struct GlobalContext;
+
 class GILGen {
 public:
     GILGen() = default;
@@ -18,13 +20,15 @@ public:
     );
 
     gil::Global *generateGlobal(
-        gil::Module *module, ast::VarLetDecl *decl,
-        llvm::BumpPtrAllocator &arena
+        gil::Module *module, ast::VarLetDecl *decl, GlobalContext &globalCtx
     );
 
     gil::Function *generateFunction(
-        gil::Module *module, ast::FunctionDecl *decl,
-        llvm::BumpPtrAllocator &arena
+        gil::Module *module, ast::FunctionDecl *decl, GlobalContext &globalCtx
+    );
+
+    gil::Function *_generateFunctionTest(
+        ast::FunctionDecl *decl, llvm::BumpPtrAllocator &arena
     );
 
     /// @brief Generate a GIL module from an AST module declaration

--- a/include/Sema/ImportManager.hpp
+++ b/include/Sema/ImportManager.hpp
@@ -82,12 +82,15 @@ public:
     {
         bool success = true;
         assert(
-            !_importStack.empty()
-            && "Import stack should never be empty when handling imports"
+            _context.getSourceManager()
+            && "SourceManager must be available to handle imports"
         );
+        FileID currentFile = importLoc.isValid()
+            ? _context.getSourceManager()->getFileID(importLoc)
+            : _importStack.back();
         for (auto selector : path.selectors) {
             if (!handleImport(
-                    importLoc, path.components, selector, _importStack.back(),
+                    importLoc, path.components, selector, currentFile,
                     intoScope, visibility
                 )) {
                 success = false;

--- a/include/Sema/ImportManager.hpp
+++ b/include/Sema/ImportManager.hpp
@@ -42,6 +42,15 @@ class ImportManager {
     llvm::ArrayRef<std::string> _importPaths;
     /// @brief Allocator for scope tables created during imports.
     llvm::BumpPtrAllocator _scopeTableAllocator;
+    /// @brief The list of imports that were skipped due to being private.
+    /// This list contains for each skipped import:
+    /// - The source location of the import declaration
+    /// - The import path
+    /// This is used to defer the processing of private imports until the
+    /// end of the compilation. If linking is required, these imports will be
+    /// processed so that the necessary symbols are available for linking.
+    llvm::SmallVector<std::tuple<SourceLocation, ast::ImportPath>, 4>
+        _skippedImports;
 
 public:
     ImportManager(
@@ -71,9 +80,14 @@ public:
     }
 
     /// @brief Handles an import declaration. It is assumed that the import
-    /// path is relative to the current file (the top of the import stack).
+    /// path is relative to the location of the import declaration, or to the
+    /// location at the top of the import stack if the location is invalid (for
+    /// default imports).
+    /// @param importLoc The source location of the import declaration.
     /// @param path The import path to handle.
     /// @param intoScope The scope to import the declarations into.
+    /// @param visibility The visibility of the import (public to re-export, or
+    /// private).
     /// @return Returns true if the import was successful, false otherwise.
     bool handleImport(
         SourceLocation importLoc, ast::ImportPath path, ScopeTable *intoScope,
@@ -99,6 +113,17 @@ public:
 
         return success;
     }
+
+    void addSkippedImport(SourceLocation loc, ast::ImportPath path)
+    {
+        _skippedImports.emplace_back(loc, path);
+    }
+
+    /// @brief Process all previously skipped private imports.
+    /// This should be called at the end of the compilation, if linking is
+    /// required.
+    /// @return Returns true if all imports were successful, false otherwise.
+    bool processSkippedImports();
 
 private:
     /// @brief Handles a single import selector. It is assumed that the import

--- a/include/Sema/ScopeTable.hpp
+++ b/include/Sema/ScopeTable.hpp
@@ -76,7 +76,10 @@ public:
     /// @brief Generate a global scope table for a module
     /// @param node The module to visit
     /// @param importManager The import manager to use for resolving imports.
-    ScopeTable(ast::ModuleDecl *node, ImportManager *importManager = nullptr);
+    ScopeTable(
+        ast::ModuleDecl *node, ImportManager *importManager = nullptr,
+        bool skipPrivateImports = false
+    );
 
     /// @brief Returns the parent scope table.
     ScopeTable *getParent() const { return _parent; }

--- a/lib/GIL/Module.cpp
+++ b/lib/GIL/Module.cpp
@@ -19,4 +19,14 @@ void Module::deleteFunction(Function *f)
     _functions.remove(f);
 }
 
+gil::Function *Module::getFunctionByDecl(ast::FunctionDecl *decl)
+{
+    for (auto &fn : _functions) {
+        if (fn.getDecl() == decl) {
+            return &fn;
+        }
+    }
+    return nullptr;
+}
+
 } // end namespace glu::gil

--- a/lib/GILGen/Context.cpp
+++ b/lib/GILGen/Context.cpp
@@ -8,9 +8,12 @@ using namespace glu::gilgen;
 using namespace glu::ast;
 
 glu::gilgen::Context::Context(
-    gil::Module *module, ast::FunctionDecl *decl, llvm::BumpPtrAllocator &arena
+    gil::Module *module, ast::FunctionDecl *decl, GlobalContext &globalCtx
 )
-    : _module(module), _functionDecl(decl), _arena(arena)
+    : _module(module)
+    , _functionDecl(decl)
+    , _arena(globalCtx.arena)
+    , _globalCtx(&globalCtx)
 {
     _function = getOrCreateGILFunction(decl);
 
@@ -24,13 +27,16 @@ glu::gilgen::Context::Context(
 }
 
 glu::gilgen::Context::Context(
-    gil::Module *module, ast::VarLetDecl *decl, llvm::BumpPtrAllocator &arena
+    gil::Module *module, ast::VarLetDecl *decl, GlobalContext &globalCtx
 )
-    : _module(module), _functionDecl(nullptr), _arena(arena)
+    : _module(module)
+    , _functionDecl(nullptr)
+    , _arena(globalCtx.arena)
+    , _globalCtx(&globalCtx)
 {
     auto funcName = std::string(decl->getName()) + ".init";
     auto size = funcName.size();
-    auto funcNameStorage = static_cast<char *>(arena.Allocate(size, 1));
+    auto funcNameStorage = static_cast<char *>(_arena.Allocate(size, 1));
     std::memcpy(funcNameStorage, funcName.data(), size);
     _function = createNewGILFunction(
         llvm::StringRef(funcNameStorage, size),

--- a/lib/GILGen/Context.hpp
+++ b/lib/GILGen/Context.hpp
@@ -13,18 +13,6 @@
 
 namespace glu::gilgen {
 
-/// @brief The context around the GIL module being generated.
-struct GlobalContext {
-    gil::Module *module;
-    llvm::BumpPtrAllocator &arena;
-    llvm::DenseSet<ast::FunctionDecl *> _inlinableFunctions;
-
-    GlobalContext(gil::Module *module, llvm::BumpPtrAllocator &arena)
-        : module(module), arena(arena)
-    {
-    }
-};
-
 /// @brief The context/builder for the GIL code generation within a function.
 class Context {
     gil::Function *_function;

--- a/lib/GILGen/Context.hpp
+++ b/lib/GILGen/Context.hpp
@@ -11,10 +11,21 @@
 #include "Instructions.hpp"
 #include "Module.hpp"
 
-
 namespace glu::gilgen {
 
-/// @brief The context/builder for the GIL code generation.
+/// @brief The context around the GIL module being generated.
+struct GlobalContext {
+    gil::Module *module;
+    llvm::BumpPtrAllocator &arena;
+    llvm::DenseSet<ast::FunctionDecl *> _inlinableFunctions;
+
+    GlobalContext(gil::Module *module, llvm::BumpPtrAllocator &arena)
+        : module(module), arena(arena)
+    {
+    }
+};
+
+/// @brief The context/builder for the GIL code generation within a function.
 class Context {
     gil::Function *_function;
     gil::BasicBlock *_currentBB;
@@ -23,10 +34,11 @@ class Context {
     ast::FunctionDecl *_functionDecl;
     llvm::BumpPtrAllocator &_arena;
     ast::ASTNode *_sourceLocNode = nullptr;
+    GlobalContext *_globalCtx = nullptr;
 
 public:
-    Context(gil::Module *module, ast::FunctionDecl *decl, llvm::BumpPtrAllocator &arena);
-    Context(gil::Module *module, ast::VarLetDecl *decl, llvm::BumpPtrAllocator &arena);
+    Context(gil::Module *module, ast::FunctionDecl *decl, GlobalContext &globalCtx);
+    Context(gil::Module *module, ast::VarLetDecl *decl, GlobalContext &globalCtx);
     Context(gil::Module *module, gil::Function *function, llvm::BumpPtrAllocator &arena);
 
     /// Returns the AST function being compiled.

--- a/lib/GILGen/Context.hpp
+++ b/lib/GILGen/Context.hpp
@@ -115,14 +115,19 @@ private:
     glu::gil::Function *getOrCreateGILFunction(glu::ast::FunctionDecl *fn)
     {
         // Try to find an existing function by FunctionDecl
-        for (auto &function : _module->getFunctions()) {
-            if (fn == function.getDecl()) {
-                return &function;
-            }
+        auto *existingFn = _module->getFunctionByDecl(fn);
+        if (existingFn) {
+            return existingFn;
         }
 
         // Otherwise, create a new GIL function
-        return createNewGILFunction(fn->getName(), fn->getType(), fn);
+        auto *newFn = createNewGILFunction(fn->getName(), fn->getType(), fn);
+
+        if (_globalCtx && fn->hasAttribute(ast::AttributeKind::InlineKind)) {
+            _globalCtx->_inlinableFunctions.insert(fn);
+        }
+
+        return newFn;
     }
 
     glu::gil::Function *createNewGILFunction(llvm::StringRef name, glu::types::FunctionTy *type, ast::FunctionDecl *fn)

--- a/lib/GILGen/GILGenStmt.cpp
+++ b/lib/GILGen/GILGenStmt.cpp
@@ -362,13 +362,4 @@ gil::Module *GILGen::generateModule(
     return gilModule;
 }
 
-gil::Function *GILGen::_generateFunctionTest(
-    ast::FunctionDecl *decl, llvm::BumpPtrAllocator &arena
-)
-{
-    auto gilModule = new (arena) gil::Module("test_module");
-    GlobalContext globalCtx(gilModule, arena);
-    return generateFunction(gilModule, decl, globalCtx);
-}
-
 } // namespace glu::gilgen

--- a/lib/GILGen/GILGenStmt.cpp
+++ b/lib/GILGen/GILGenStmt.cpp
@@ -347,6 +347,18 @@ gil::Module *GILGen::generateModule(
         }
     }
 
+    // Generate GIL for all inlinable functions from other modules
+    while (!globalCtx._inlinableFunctions.empty()) {
+        auto fn = *globalCtx._inlinableFunctions.begin();
+        globalCtx._inlinableFunctions.erase(fn);
+        if (auto *gilFn = gilModule->getFunctionByDecl(fn);
+            gilFn && gilFn->getBasicBlockCount()) {
+            // Already generated
+            continue;
+        }
+        generateFunction(gilModule, fn, globalCtx);
+    }
+
     return gilModule;
 }
 

--- a/lib/Sema/CSWalker.cpp
+++ b/lib/Sema/CSWalker.cpp
@@ -592,8 +592,8 @@ public:
 
     void preVisitModuleDecl(glu::ast::ModuleDecl *node)
     {
-        _scopeTable
-            = new (_scopeTableAllocator) ScopeTable(node, _importManager);
+        _scopeTable = new (_scopeTableAllocator)
+            ScopeTable(node, _importManager, _skipBodies);
         UnresolvedNameTyMapper mapper(*_scopeTable, _diagManager, _context);
 
         mapper.visit(node);

--- a/stdlib/defaultImports/operators.glu
+++ b/stdlib/defaultImports/operators.glu
@@ -1,68 +1,68 @@
 
 #define EQUALITY_OPERATORS(Type) \
-    public func ==(a: Type, b: Type) -> Bool { \
+    @inline public func ==(a: Type, b: Type) -> Bool { \
         return builtins::builtin_eq(a, b); \
     } \
-    public func !=(a: Type, b: Type) -> Bool { \
+    @inline public func !=(a: Type, b: Type) -> Bool { \
         return !builtins::builtin_eq(a, b); \
     }
 
 #define COMPARISON_OPERATORS(Type) \
     EQUALITY_OPERATORS(Type) \
-    public func <(a: Type, b: Type) -> Bool { \
+    @inline public func <(a: Type, b: Type) -> Bool { \
         return builtins::builtin_lt(a, b); \
     } \
-    public func <=(a: Type, b: Type) -> Bool { \
+    @inline public func <=(a: Type, b: Type) -> Bool { \
         return builtins::builtin_le(a, b); \
     } \
-    public func >(a: Type, b: Type) -> Bool { \
+    @inline public func >(a: Type, b: Type) -> Bool { \
         return builtins::builtin_gt(a, b); \
     } \
-    public func >=(a: Type, b: Type) -> Bool { \
+    @inline public func >=(a: Type, b: Type) -> Bool { \
         return builtins::builtin_ge(a, b); \
     }
 
 #define ARITHMETIC_OPERATORS(Type) \
-    public func +(a: Type, b: Type) -> Type { \
+    @inline public func +(a: Type, b: Type) -> Type { \
         return builtins::builtin_add(a, b); \
     } \
-    public func -(a: Type, b: Type) -> Type { \
+    @inline public func -(a: Type, b: Type) -> Type { \
         return builtins::builtin_sub(a, b); \
     } \
-    public func *(a: Type, b: Type) -> Type { \
+    @inline public func *(a: Type, b: Type) -> Type { \
         return builtins::builtin_mul(a, b); \
     } \
-    public func /(a: Type, b: Type) -> Type { \
+    @inline public func /(a: Type, b: Type) -> Type { \
         return builtins::builtin_div(a, b); \
     } \
-    public func -(a: Type) -> Type { \
+    @inline public func -(a: Type) -> Type { \
         return 0 - a; \
     } \
-    public func +(a: Type) -> Type { \
+    @inline public func +(a: Type) -> Type { \
         return a; \
     } \
     COMPARISON_OPERATORS(Type)
 
 #define BITWISE_OPERATORS(Type) \
-    public func &(a: Type, b: Type) -> Type { \
+    @inline public func &(a: Type, b: Type) -> Type { \
         return builtins::builtin_and(a, b); \
     } \
-    public func |(a: Type, b: Type) -> Type { \
+    @inline public func |(a: Type, b: Type) -> Type { \
         return builtins::builtin_or(a, b); \
     } \
-    public func ^(a: Type, b: Type) -> Type { \
+    @inline public func ^(a: Type, b: Type) -> Type { \
         return builtins::builtin_xor(a, b); \
     } \
-    public func <<(a: Type, b: Type) -> Type { \
+    @inline public func <<(a: Type, b: Type) -> Type { \
         return builtins::builtin_shl(a, b); \
     } \
-    public func >>(a: Type, b: Type) -> Type { \
+    @inline public func >>(a: Type, b: Type) -> Type { \
         return builtins::builtin_shr(a, b); \
     } \
-    public func ~(a: Type) -> Type { \
+    @inline public func ~(a: Type) -> Type { \
         return builtins::builtin_compl(a); \
     } \
-    public func %(a: Type, b: Type) -> Type { \
+    @inline public func %(a: Type, b: Type) -> Type { \
         return builtins::builtin_mod(a, b); \
     } \
     ARITHMETIC_OPERATORS(Type)
@@ -80,6 +80,6 @@ ARITHMETIC_OPERATORS(Float32)
 ARITHMETIC_OPERATORS(Float64)
 EQUALITY_OPERATORS(Bool)
 
-public func !(a: Bool) -> Bool {
+@inline public func !(a: Bool) -> Bool {
     return a == false;
 }

--- a/stdlib/defaultImports/stringType.glu
+++ b/stdlib/defaultImports/stringType.glu
@@ -4,7 +4,7 @@ public struct String {
     isAllocated: Bool
 }
 
-@no_mangling public func glu_createConstantString(s: *Char, length: Int) -> String {
+@inline @no_mangling public func glu_createConstantString(s: *Char, length: Int) -> String {
     var str: String;
 
     str.data = s;

--- a/test/GILGen/GILGenStmt.cpp
+++ b/test/GILGen/GILGenStmt.cpp
@@ -33,8 +33,7 @@ TEST(GILGenStmt, Empty)
     auto decl = module->getDecls().front();
     auto fn = llvm::cast<FunctionDecl>(decl);
     llvm::BumpPtrAllocator arena;
-    auto gilModule = new (arena) gil::Module("filename");
-    auto *f = GILGen().generateFunction(gilModule, fn, arena);
+    auto *f = GILGen()._generateFunctionTest(fn, arena);
     EXPECT_EQ(f->getName(), "test");
     EXPECT_EQ(f->getBasicBlockCount(), 1);
     auto bb = f->getEntryBlock();

--- a/test/GILGen/GILGenStmt.cpp
+++ b/test/GILGen/GILGenStmt.cpp
@@ -33,7 +33,9 @@ TEST(GILGenStmt, Empty)
     auto decl = module->getDecls().front();
     auto fn = llvm::cast<FunctionDecl>(decl);
     llvm::BumpPtrAllocator arena;
-    auto *f = GILGen()._generateFunctionTest(fn, arena);
+    auto gilModule = new (arena) gil::Module("test_module");
+    GlobalContext globalCtx(gilModule, arena);
+    auto *f = GILGen().generateFunction(gilModule, fn, globalCtx);
     EXPECT_EQ(f->getName(), "test");
     EXPECT_EQ(f->getBasicBlockCount(), 1);
     auto bb = f->getEntryBlock();

--- a/test/GILGen/GILGenTernary.cpp
+++ b/test/GILGen/GILGenTernary.cpp
@@ -36,8 +36,7 @@ TEST(GILGenExpr, TernaryBasic)
     auto decl = module->getDecls().front();
     auto *fn = llvm::cast<FunctionDecl>(decl);
     llvm::BumpPtrAllocator arena;
-    auto gilModule = new (arena) gil::Module("filename");
-    auto *f = GILGen().generateFunction(gilModule, fn, arena);
+    auto *f = GILGen()._generateFunctionTest(fn, arena);
 
     // Expect 5 basic blocks: entry + then + else + result + unreachable (after
     // explicit return)

--- a/test/GILGen/GILGenTernary.cpp
+++ b/test/GILGen/GILGenTernary.cpp
@@ -36,7 +36,9 @@ TEST(GILGenExpr, TernaryBasic)
     auto decl = module->getDecls().front();
     auto *fn = llvm::cast<FunctionDecl>(decl);
     llvm::BumpPtrAllocator arena;
-    auto *f = GILGen()._generateFunctionTest(fn, arena);
+    auto gilModule = new (arena) gil::Module("test_module");
+    GlobalContext globalCtx(gilModule, arena);
+    auto *f = GILGen().generateFunction(gilModule, fn, globalCtx);
 
     // Expect 5 basic blocks: entry + then + else + result + unreachable (after
     // explicit return)

--- a/test/functional/IRGen/inline.glu
+++ b/test/functional/IRGen/inline.glu
@@ -1,7 +1,7 @@
 //
 // RUN: split-file %s %t
-// RUN: gluc %t/main.glu --print-llvm-ir | FileCheck -v --check-prefix=CHECK-O0 %s
-// RUN: gluc %t/main.glu --print-llvm-ir | opt -S -O1 - | FileCheck -v --check-prefix=CHECK-O1 %s
+// RUN: gluc %t/main.glu --print-llvm-ir -O0 | FileCheck -v --check-prefix=CHECK-O0 %s
+// RUN: gluc %t/main.glu --print-llvm-ir -O1 | FileCheck -v --check-prefix=CHECK-O1 %s
 //
 
 //--- lib.glu

--- a/test/functional/IRGen/inline.glu
+++ b/test/functional/IRGen/inline.glu
@@ -1,0 +1,31 @@
+//
+// RUN: split-file %s %t
+// RUN: gluc %t/main.glu --print-llvm-ir | FileCheck -v --check-prefix=CHECK-O0 %s
+// RUN: gluc %t/main.glu --print-llvm-ir | opt -S -O1 - | FileCheck -v --check-prefix=CHECK-O1 %s
+//
+
+//--- lib.glu
+
+@inline @no_mangling public func inlinableFunction() -> Int {
+    return 42;
+}
+
+//--- main.glu
+
+import lib;
+
+// CHECK-O0: define i32 @main()
+// CHECK-O0: %0 = call i32 @inlinableFunction()
+// CHECK-O0: ret i32 %0
+
+// CHECK-O0: define linkonce_odr i32 @inlinableFunction()
+// CHECK-O0: ret i32 42
+
+// CHECK-O1: define {{.*}}i32 @main()
+// CHECK-O1-NOT: call i32 @inlinableFunction()
+// CHECK-O1: ret i32 42
+// CHECK-O1-NOT: define linkonce_odr i32 @inlinableFunction()
+
+func main() -> Int {
+    return lib::inlinableFunction();
+}

--- a/test/functional/Sema/import_cyclic.glu
+++ b/test/functional/Sema/import_cyclic.glu
@@ -10,13 +10,13 @@ import liba;
 
 //--- liba.glu
 
-import libb;
+public import libb;
 
 //--- libb.glu
 
-import libc;
+public import libc;
 
 //--- libc.glu
 
-// CHECK: 3:1: error: Cyclic import detected, module imports itself indirectly
-import liba;
+// CHECK: 3:8: error: Cyclic import detected, module may be re-exporting itself
+public import liba;

--- a/test/functional/Sema/import_self.glu
+++ b/test/functional/Sema/import_self.glu
@@ -2,5 +2,5 @@
 // RUN: not gluc -c %s -o %t.o 2>&1 | FileCheck -v %s
 //
 
-// CHECK: 6:1: error: Cyclic import detected, module imports itself indirectly
+// CHECK: 6:1: error: Cyclic import detected, module may be re-exporting itself
 import import_self;

--- a/test/functional/run/import_circular.glu
+++ b/test/functional/run/import_circular.glu
@@ -1,0 +1,76 @@
+//
+// RUN: split-file %s %t
+// RUN: gluc -c %t/person.glu -o %t/person.o
+// RUN: gluc -c %t/school.glu -o %t/school.o
+// RUN: gluc -c %t/puts.glu -o %t/puts.o
+// RUN: gluc %t/main.glu -o %t/main
+// RUN: %t/main | FileCheck -v %s
+// RUN: gluc -c %t/indirect.glu -o %t/indirect.o
+// RUN: gluc %t/indirect_main.glu -o %t/indirect_main
+// RUN: %t/indirect_main | FileCheck -v %s
+
+//--- person.glu
+
+import school;
+
+public func getName() -> *Char {
+    return "Emil";
+}
+
+public func getSchool() -> *Char {
+    return school::getBestSchool();
+}
+
+//--- school.glu
+
+import person;
+
+public func getBestSchool() -> *Char {
+    return "Epitech";
+}
+
+public func getBestStudent() -> *Char {
+    return person::getName();
+}
+
+//--- puts.glu
+
+@no_mangling public func puts(s: *Char);
+
+//--- main.glu
+
+import person;
+import school;
+import puts::puts;
+
+func main() {
+    // CHECK: Emil
+    puts(person::getName());
+    // CHECK: Epitech
+    puts(person::getSchool());
+    // CHECK: Emil
+    puts(school::getBestStudent());
+    // CHECK: Epitech
+    puts(school::getBestSchool());
+}
+
+//--- indirect.glu
+
+import person;
+import school;
+import puts::puts;
+
+public func printInfo() {
+    puts(person::getName());
+    puts(person::getSchool());
+    puts(school::getBestStudent());
+    puts(school::getBestSchool());
+}
+
+//--- indirect_main.glu
+
+import indirect;
+
+func main() {
+    indirect::printInfo();
+}

--- a/tools/gluc/sources/CompilerDriver.cpp
+++ b/tools/gluc/sources/CompilerDriver.cpp
@@ -35,6 +35,10 @@ std::vector<std::string> CompilerDriver::findImportedObjectFiles()
 {
     std::vector<std::string> importedFiles;
 
+    // First, process any skipped private imports to ensure they are handled
+    // before we look for their object files.
+    _importManager->processSkippedImports();
+
     auto const &importedFilesMap = _importManager->getImportedFiles();
     auto *sourceManager = _importManager->getASTContext().getSourceManager();
 


### PR DESCRIPTION
Closes #588: Implement inline attribute
Closes #554: Implement fastConstrainAST

Compiling a simple `test/functional/helloworld.glu` goes from 0.51s to 0.15s, a **70%** reduction in compile time. The reduction would be even greater for a file importing a lot of different modules.

This also adds support for delaying processing of private imports. This means that cyclic dependencies are now supported, as long as the imports are private.