### PR TITLE
Feature: enhance diagnostic system with optional notes

### DIFF
--- a/include/Basic/Diagnostic.hpp
+++ b/include/Basic/Diagnostic.hpp
@@ -24,6 +24,7 @@ class Diagnostic {
     DiagnosticSeverity _severity;
     SourceLocation _location;
     std::string _message;
+    std::unique_ptr<Diagnostic> _note;
 
 public:
     /// @brief Construct a diagnostic message.
@@ -32,9 +33,12 @@ public:
     /// @param message The message text.
     Diagnostic(
         DiagnosticSeverity severity, SourceLocation location,
-        llvm::Twine const &message
+        llvm::Twine const &message, std::unique_ptr<Diagnostic> note = nullptr
     )
-        : _severity(severity), _location(location), _message(message.str())
+        : _severity(severity)
+        , _location(location)
+        , _message(message.str())
+        , _note(std::move(note))
     {
     }
 
@@ -46,6 +50,9 @@ public:
 
     /// @return The message text.
     std::string const &getMessage() const { return _message; }
+
+    /// @return An optional note associated with this diagnostic.
+    Diagnostic const *getNote() const { return _note.get(); }
 };
 
 /// @class DiagnosticManager
@@ -66,22 +73,22 @@ public:
     /// @brief Reports an error at the specified source location.
     /// @param loc The source location where the error occurred.
     /// @param message The error message.
-    void error(SourceLocation loc, llvm::Twine const &message);
+    void error(SourceLocation loc, llvm::Twine const &message, std::unique_ptr<Diagnostic> note = nullptr);
 
     /// @brief Reports a warning at the specified source location.
     /// @param loc The source location where the warning occurred.
     /// @param message The warning message.
-    void warning(SourceLocation loc, llvm::Twine const &message);
+    void warning(SourceLocation loc, llvm::Twine const &message, std::unique_ptr<Diagnostic> note = nullptr);
 
     /// @brief Reports an informational note at the specified source location.
     /// @param loc The source location where the note is relevant.
     /// @param message The note message.
-    void note(SourceLocation loc, llvm::Twine const &message);
+    void note(SourceLocation loc, llvm::Twine const &message, std::unique_ptr<Diagnostic> note = nullptr);
 
     /// @brief Reports a fatal error and stops compilation.
     /// @param loc The source location where the fatal error occurred.
     /// @param message The fatal error message.
-    void fatal(SourceLocation loc, llvm::Twine const &message);
+    void fatal(SourceLocation loc, llvm::Twine const &message, std::unique_ptr<Diagnostic> note = nullptr);
 
     /// @brief Prints all collected diagnostics to the specified output stream.
     /// @param os The output stream where diagnostics will be printed.
@@ -105,7 +112,7 @@ private:
     /// @param message The message text.
     void addDiagnostic(
         DiagnosticSeverity severity, SourceLocation loc,
-        llvm::Twine const &message
+        llvm::Twine const &message, std::unique_ptr<Diagnostic> note = nullptr
     );
 
     /// @brief Formats and prints a single diagnostic message.

--- a/lib/Basic/Diagnostic.cpp
+++ b/lib/Basic/Diagnostic.cpp
@@ -5,10 +5,9 @@
 namespace glu {
 
 void DiagnosticManager::addDiagnostic(
-    DiagnosticSeverity severity, SourceLocation loc, llvm::Twine const &message
-)
+    DiagnosticSeverity severity, SourceLocation loc, llvm::Twine const &message, std::unique_ptr<Diagnostic> note)
 {
-    _messages.emplace_back(severity, loc, message.str());
+    _messages.emplace_back(severity, loc, message.str(), std::move(note));
 
     // Set the error flag if this is an error or fatal error
     if (not _hasErrors)
@@ -20,24 +19,24 @@ void DiagnosticManager::addDiagnostic(
 #endif
 }
 
-void DiagnosticManager::error(SourceLocation loc, llvm::Twine const &message)
+void DiagnosticManager::error(SourceLocation loc, llvm::Twine const &message, std::unique_ptr<Diagnostic> note)
 {
-    addDiagnostic(DiagnosticSeverity::Error, loc, std::move(message));
+    addDiagnostic(DiagnosticSeverity::Error, loc, std::move(message), std::move(note));
 }
 
-void DiagnosticManager::warning(SourceLocation loc, llvm::Twine const &message)
+void DiagnosticManager::warning(SourceLocation loc, llvm::Twine const &message, std::unique_ptr<Diagnostic> note)
 {
-    addDiagnostic(DiagnosticSeverity::Warning, loc, std::move(message));
+    addDiagnostic(DiagnosticSeverity::Warning, loc, std::move(message), std::move(note));
 }
 
-void DiagnosticManager::note(SourceLocation loc, llvm::Twine const &message)
+void DiagnosticManager::note(SourceLocation loc, llvm::Twine const &message, std::unique_ptr<Diagnostic> note)
 {
-    addDiagnostic(DiagnosticSeverity::Note, loc, std::move(message));
+    addDiagnostic(DiagnosticSeverity::Note, loc, std::move(message), std::move(note));
 }
 
-void DiagnosticManager::fatal(SourceLocation loc, llvm::Twine const &message)
+void DiagnosticManager::fatal(SourceLocation loc, llvm::Twine const &message, std::unique_ptr<Diagnostic> note)
 {
-    addDiagnostic(DiagnosticSeverity::Fatal, loc, std::move(message));
+    addDiagnostic(DiagnosticSeverity::Fatal, loc, std::move(message), std::move(note));
 }
 
 void DiagnosticManager::printDiagnostic(
@@ -94,6 +93,9 @@ void DiagnosticManager::printDiagnostic(
     } else {
         os << "^\n"; // Fallback if column is 0
     }
+
+    if (msg.getNote() != nullptr)
+        printDiagnostic(os, *msg.getNote());
 }
 
 void DiagnosticManager::printAll(llvm::raw_ostream &os)

--- a/lib/Sema/SemanticPass/ValidMainChecker.hpp
+++ b/lib/Sema/SemanticPass/ValidMainChecker.hpp
@@ -19,7 +19,6 @@ namespace glu::sema {
 class ValidMainChecker : public ast::ASTWalker<ValidMainChecker, void> {
     DiagnosticManager &_diagManager;
     ast::FunctionDecl *_firstMainFunction = nullptr;
-    bool _hasShownNote = false;
 
 public:
     explicit ValidMainChecker(DiagnosticManager &diagManager)
@@ -40,16 +39,13 @@ public:
         } else {
             _diagManager.error(
                 node->getLocation(),
-                "multiple definitions of main function found"
-            );
-            // Show note pointing to first definition only on first duplicate
-            if (!_hasShownNote) {
-                _diagManager.note(
+                "multiple definitions of main function found",
+                std::make_unique<Diagnostic>(
+                    DiagnosticSeverity::Note,
                     _firstMainFunction->getLocation(),
                     "first definition of main function here"
-                );
-                _hasShownNote = true;
-            }
+                )
+            );
         }
 
         auto *funcType = node->getType();
@@ -115,7 +111,7 @@ private:
     /// **Char)
     bool validateTwoParamMain(
         llvm::ArrayRef<glu::ast::ParamDecl *> params,
-        glu::SourceLocation location
+        [[maybe_unused]] glu::SourceLocation location
     )
     {
         auto result = true;

--- a/test/functional/Sema/bad_main.glu
+++ b/test/functional/Sema/bad_main.glu
@@ -2,26 +2,28 @@
 // RUN: not gluc %s 2>&1 | FileCheck %s
 //
 
-// CHECK: bad_main.glu:7:1: error: main function must return Void or Int
-// CHECK: bad_main.glu:7:1: note: first definition of main function here
+// CHECK: bad_main.glu:6:1: error: main function must return Void or Int
 func main() -> Float {
     return 0;
 }
 
 // CHECK: bad_main.glu:13:1: error: multiple definitions of main function found
+// CHECK: bad_main.glu:6:1: note: first definition of main function here
 // CHECK: bad_main.glu:13:1: error: main function must have 0, 2, or 3 parameters, got 1
 func main(arg: Int) -> Int {
     return arg;
 }
 
-// CHECK: bad_main.glu:18:1: error: multiple definitions of main function found
+// CHECK: bad_main.glu:19:1: error: multiple definitions of main function found
+// CHECK: bad_main.glu:6:1: note: first definition of main function here
 func main() -> Int {
     return 0;
 }
 
-// CHECK: bad_main.glu:25:1: error: multiple definitions of main function found
-// CHECK: bad_main.glu:25:11: error: first parameter of main function must be of type Int
-// CHECK: bad_main.glu:25:24: error: second parameter of main function must be of type **Char
+// CHECK: bad_main.glu:27:1: error: multiple definitions of main function found
+// CHECK: bad_main.glu:6:1: note: first definition of main function here
+// CHECK: bad_main.glu:27:11: error: first parameter of main function must be of type Int
+// CHECK: bad_main.glu:27:24: error: second parameter of main function must be of type **Char
 func main(argc: Float, argv: **Int) -> Int {
     return 0;
 }


### PR DESCRIPTION
Closes #599 

This pull request adds support for associating an optional note with each diagnostic message, enabling better error reporting by linking related diagnostics together. The changes update both the `Diagnostic` and `DiagnosticManager` classes to handle notes, propagate them through reporting methods, and ensure notes are printed alongside their parent diagnostics. The test output is also updated to reflect the new note-handling behavior.

Diagnostic infrastructure enhancements:

* Added a `std::unique_ptr<Diagnostic> _note` member to the `Diagnostic` class, updated its constructor to accept an optional note, and provided a `getNote()` accessor for retrieving the note. (`include/Basic/Diagnostic.hpp`, [[1]](diffhunk://#diff-8bb0b21b143133b2a74837fc904dec3530be87c5d5b29543d207ce79839c862cR27) [[2]](diffhunk://#diff-8bb0b21b143133b2a74837fc904dec3530be87c5d5b29543d207ce79839c862cL35-R41) [[3]](diffhunk://#diff-8bb0b21b143133b2a74837fc904dec3530be87c5d5b29543d207ce79839c862cR53-R55)
* Updated all reporting methods in `DiagnosticManager` (`error`, `warning`, `note`, `fatal`, and `addDiagnostic`) to accept an optional note and pass it through to diagnostics. (`include/Basic/Diagnostic.hpp`, [[1]](diffhunk://#diff-8bb0b21b143133b2a74837fc904dec3530be87c5d5b29543d207ce79839c862cL69-R91) [[2]](diffhunk://#diff-8bb0b21b143133b2a74837fc904dec3530be87c5d5b29543d207ce79839c862cL108-R115); `lib/Basic/Diagnostic.cpp`, [[3]](diffhunk://#diff-732a0c937e61ded72062014f9d4bbe7171508a698debe58996cce951bfdc312eL8-R10) [[4]](diffhunk://#diff-732a0c937e61ded72062014f9d4bbe7171508a698debe58996cce951bfdc312eL23-R39)
* Modified diagnostic printing to recursively print associated notes after their parent diagnostic message. (`lib/Basic/Diagnostic.cpp`, [lib/Basic/Diagnostic.cppR96-R98](diffhunk://#diff-732a0c937e61ded72062014f9d4bbe7171508a698debe58996cce951bfdc312eR96-R98))

Semantic analysis improvements:

* Refactored `ValidMainChecker` to attach a note directly to the error for multiple `main` definitions, removing the previous flag-based approach for showing the note only once. (`lib/Sema/SemanticPass/ValidMainChecker.hpp`, [[1]](diffhunk://#diff-62337819877413cf52ff982edf1853c88f1d18e7c4e94c05e1b82e32034bf0e8L22) [[2]](diffhunk://#diff-62337819877413cf52ff982edf1853c88f1d18e7c4e94c05e1b82e32034bf0e8L43-L52)

Test updates:

* Updated the functional test `bad_main.glu` to match the new diagnostic output, ensuring notes are correctly associated and printed with errors. (`test/functional/Sema/bad_main.glu`, [test/functional/Sema/bad_main.gluL5-R26](diffhunk://#diff-f7684c0985c89717f677262bbdef47a8db89c58e6a8c4606c471a746ebf7541dL5-R26))