### PR TITLE
Fix: imported globals not linking correctly

### DIFF
--- a/include/GIL/Global.hpp
+++ b/include/GIL/Global.hpp
@@ -66,12 +66,19 @@ private:
     Function *_initializer;
     glu::ast::VarLetDecl *_decl;
 
+    /// @brief Indicates whether the global has an initializer function.
+    bool _hasInitializer = false;
+
 public:
     Global(
-        llvm::StringRef name, glu::types::TypeBase *type, Function *initializer,
+        llvm::StringRef name, glu::types::TypeBase *type, bool hasInitializer,
         glu::ast::VarLetDecl *decl
     )
-        : _name(name), _type(type), _initializer(initializer), _decl(decl)
+        : _name(name)
+        , _type(type)
+        , _initializer(nullptr)
+        , _decl(decl)
+        , _hasInitializer(hasInitializer)
     {
     }
 
@@ -81,7 +88,12 @@ public:
     glu::types::TypeBase *getType() const { return _type; }
 
     Function *getInitializer() const { return _initializer; }
-    void setInitializer(Function *initializer) { _initializer = initializer; }
+    void setInitializer(Function *initializer)
+    {
+        assert(_hasInitializer && "Global does not have an initializer");
+        _initializer = initializer;
+    }
+    bool hasInitializer() const { return _hasInitializer; }
 
     /// Returns the parent module of this function
     Module *getParent() const { return _parentModule; }

--- a/lib/GIL/GILPrinter.cpp
+++ b/lib/GIL/GILPrinter.cpp
@@ -40,6 +40,9 @@ void GILPrinter::beforeVisitGlobal(Global *global)
         out << " = ";
         llvm::WithColor(out, llvm::raw_ostream::BLUE)
             << "@" << global->getInitializer()->getName();
+    } else if (global->hasInitializer()) {
+        out << " = ";
+        llvm::WithColor(out, llvm::raw_ostream::BLUE) << "<external>";
     }
     out << ";\n\n";
 }

--- a/lib/GILGen/GILGenStmt.cpp
+++ b/lib/GILGen/GILGenStmt.cpp
@@ -307,8 +307,9 @@ gil::Global *GILGen::getOrCreateGlobal(
         }
     }
 
-    auto *global = new (arena)
-        gil::Global(decl->getName(), decl->getType(), nullptr, decl);
+    auto *global = new (arena) gil::Global(
+        decl->getName(), decl->getType(), decl->getValue() != nullptr, decl
+    );
     module->addGlobal(global);
     return global;
 }


### PR DESCRIPTION
Closes #612 
Globals can have initializers without having an initializer function set if they were imported. This fixes how they are generated.