### PR TITLE
fix: support nested struct initializer expressions

### DIFF
--- a/lib/Sema/ConstraintSystem/LocalCSWalker.cpp
+++ b/lib/Sema/ConstraintSystem/LocalCSWalker.cpp
@@ -329,8 +329,10 @@ public:
         );
     }
 
-    void postVisitStructInitializerExpr(glu::ast::StructInitializerExpr *node)
+    // We need to handle struct initializer outside first, so preVisit
+    void preVisitStructInitializerExpr(glu::ast::StructInitializerExpr *node)
     {
+        preVisitExprBase(node);
         auto constraint = Constraint::createStructInitialiser(
             _cs.getAllocator(), node->getType(), node
         );

--- a/test/functional/run/struct.glu
+++ b/test/functional/run/struct.glu
@@ -10,6 +10,10 @@ struct MyStruct {
     second: *Char = "secondDefault"
 }
 
+struct MyContainer {
+    content: MyStruct = {}
+}
+
 func testStruct(s: MyStruct) -> Void {
     puts(s.first);
     puts(s.second);
@@ -30,6 +34,16 @@ func main() -> Int {
     // CHECK: thirdInit
     let secondInit: MyStruct = {"secondInit", "thirdInit"};
     testStruct(secondInit);
+
+    let container: MyContainer = {};
+    // CHECK: firstDefault
+    // CHECK: secondDefault
+    testStruct(container.content);
+
+    let containerInit: MyContainer = { {"nestedInit"} };
+    // CHECK: nestedInit
+    // CHECK: secondDefault
+    testStruct(containerInit.content);
 
     return 0;
 }


### PR DESCRIPTION
Change from postVisit to preVisit, because outside structure initializers need to be resolved before the inside ones can be.
This should work with most/all cases, although this is not very robust.